### PR TITLE
feat: MSLS DeepL translation improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@
 # mu-plugins - ignore all, whitelist custom
 /web/app/mu-plugins/*
 !/web/app/mu-plugins/.gitkeep
-# !/web/app/mu-plugins/my-custom-mu-plugin/
+!/web/app/mu-plugins/msls-deepl-translate.php
 
 # Uploads
 /web/app/uploads/*

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "wpackagist-plugin/dominant-color-images": "^1.2",
     "wpackagist-plugin/individual-multisite-author": "^1.4",
     "wpackagist-plugin/webp-uploads": "^2.6",
-    "lloc/multisite-language-switcher": "^2.10",
+    "lloc/multisite-language-switcher": "dev-master",
     "wpackagist-plugin/optimum-gravatar-cache": "^1.4",
     "wpackagist-plugin/performance-lab": "^4.0",
     "wpackagist-plugin/progress-planner": "^1.9",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0c345be61d64a389f185436693f99e08",
+    "content-hash": "5cd6e4a7ba3f9ef1eb3a013d3c383b45",
     "packages": [
         {
             "name": "apermo/sovereignty",
@@ -257,16 +257,16 @@
         },
         {
             "name": "lloc/multisite-language-switcher",
-            "version": "2.10.1",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/lloc/Multisite-Language-Switcher.git",
-                "reference": "f04b60335851d0d906a5cf8e738da28726c08131"
+                "reference": "94ecc97ae3decb31a882ec9d964ef39ba8f78dc3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/lloc/Multisite-Language-Switcher/zipball/f04b60335851d0d906a5cf8e738da28726c08131",
-                "reference": "f04b60335851d0d906a5cf8e738da28726c08131",
+                "url": "https://api.github.com/repos/lloc/Multisite-Language-Switcher/zipball/94ecc97ae3decb31a882ec9d964ef39ba8f78dc3",
+                "reference": "94ecc97ae3decb31a882ec9d964ef39ba8f78dc3",
                 "shasum": ""
             },
             "require": {
@@ -287,6 +287,7 @@
                 "szepeviktor/phpstan-wordpress": "^2.0.0",
                 "wp-coding-standards/wpcs": "^3.0"
             },
+            "default-branch": true,
             "type": "wordpress-plugin",
             "autoload": {
                 "psr-4": {
@@ -315,7 +316,7 @@
             ],
             "support": {
                 "issues": "https://github.com/lloc/Multisite-Language-Switcher/issues",
-                "source": "https://github.com/lloc/Multisite-Language-Switcher/tree/2.10.1"
+                "source": "https://github.com/lloc/Multisite-Language-Switcher/tree/master"
             },
             "funding": [
                 {
@@ -323,7 +324,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-12-08T10:05:44+00:00"
+            "time": "2026-05-25T11:42:18+00:00"
         },
         {
             "name": "oscarotero/env",
@@ -3752,6 +3753,7 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
+        "lloc/multisite-language-switcher": 20,
         "roave/security-advisories": 20
     },
     "prefer-stable": true,

--- a/web/app/mu-plugins/msls-deepl-translate.php
+++ b/web/app/mu-plugins/msls-deepl-translate.php
@@ -83,8 +83,6 @@ class Translator {
 			$post_data['post_content'] = $translated_content;
 		}
 
-		// Re-slash: MSLS hands raw values to wp_insert_post, which wp_unslash's
-		// them and would otherwise strip backslashes from JSON block attributes.
 		return wp_slash( $post_data );
 	}
 

--- a/web/app/mu-plugins/msls-deepl-translate.php
+++ b/web/app/mu-plugins/msls-deepl-translate.php
@@ -4,211 +4,202 @@
  * Description: Translates title and content via DeepL when using MSLS quick-create.
  */
 
-add_action( 'rest_api_init', 'msls_deepl_register_filter', 99 );
+namespace Chrdm\MslsDeepl;
+
+use lloc\Msls\MslsBlogCollection;
+use lloc\Msls\MslsRestApi;
+use WP_Post;
+
+add_action( 'rest_api_init', [ Translator::class, 'register' ], 99 );
 
 /**
- * Replace the default "From xx:" prefix with DeepL translation.
+ * Hooks MSLS quick-create into DeepL and preserves blocks that must not be translated.
  */
-function msls_deepl_register_filter(): void {
-	remove_filter( 'msls_quick_create_post_data', [ lloc\Msls\MslsRestApi::class, 'prefix_source_language' ] );
-	add_filter( 'msls_quick_create_post_data', 'msls_deepl_translate_post_data', 10, 4 );
-}
+class Translator {
 
-/**
- * Translate post title and content via DeepL on quick-create.
- *
- * @param array    $post_data      The post data for wp_insert_post.
- * @param \WP_Post $source_post    The source post object.
- * @param int      $source_blog_id The source blog ID.
- * @param int      $target_blog_id The target blog ID.
- *
- * @return array
- */
-function msls_deepl_translate_post_data( array $post_data, \WP_Post $source_post, int $source_blog_id, int $target_blog_id ): array {
-	if ( ! function_exists( 'deepl_translate' ) ) {
-		msls_deepl_ensure_loaded();
-	}
-
-	if ( ! function_exists( 'deepl_translate' ) ) {
-		return $post_data;
-	}
-
-	$source_lang = lloc\Msls\MslsBlogCollection::get_blog_language( $source_blog_id );
-	$target_lang = lloc\Msls\MslsBlogCollection::get_blog_language( $target_blog_id );
-
-	$source_code = strtoupper( substr( $source_lang, 0, 2 ) );
-	$target_code = strtoupper( substr( $target_lang, 0, 2 ) );
-
-	// Translate title (plain text).
-	$title_response = deepl_translate( $source_code, $target_code, [ 'post_title' => $post_data['post_title'] ] );
-
-	if ( is_array( $title_response ) && ! empty( $title_response['success'] ) && isset( $title_response['translations']['post_title'] ) ) {
-		$post_data['post_title'] = $title_response['translations']['post_title'];
-	}
-
-	// Replace blocks that must not be translated (e.g. code) with opaque
-	// placeholders, so DeepL never sees their inner HTML.
-	$preserved = [];
-	$content   = msls_deepl_extract_preserved_blocks( $post_data['post_content'], $preserved );
-
-	// Wrap remaining block comments so DeepL's HTML parser leaves them intact.
-	$content = preg_replace( '/<!--(.+?)-->/', '<x><!--$1--></x>', $content );
-
-	$content_response = deepl_translate( $source_code, $target_code, [ 'post_content' => $content ] );
-
-	if ( is_array( $content_response ) && ! empty( $content_response['success'] ) && isset( $content_response['translations']['post_content'] ) ) {
-		$translated_content = $content_response['translations']['post_content'];
-		$translated_content = preg_replace( '#<x>\s*(<!--.+?-->)\s*</x>#s', '$1', $translated_content );
-		$translated_content = msls_deepl_restore_preserved_blocks( $translated_content, $preserved );
-		$post_data['post_content'] = $translated_content;
-	}
-
-	// MslsRestApi::prepare_post_data() reads raw values from $source_post and
-	// hands them to wp_insert_post(), which runs wp_unslash() on its input.
-	// Without re-slashing here, every backslash in the post data is stripped —
-	// silently corrupting JSON-encoded block attributes (e.g. Code Block Pro's
-	// "code":"...\n..." becomes "code":"...n..."), which then fails Gutenberg's
-	// block validation.
-	return wp_slash( $post_data );
-}
-
-/**
- * Returns Gutenberg block types whose content must not be translated.
- *
- * Code blocks fail Gutenberg's block validation when DeepL alters the
- * inner HTML so it no longer matches the stored attributes — Gutenberg
- * then surfaces them as "unexpected or invalid content".
- *
- * @return string[] Block names like 'wp:kevinbatdorf/code-block-pro'.
- */
-function msls_deepl_preserved_block_types(): array {
 	/**
-	 * Filters the Gutenberg block types whose content must not be translated.
+	 * Gutenberg block types whose content must not be translated.
 	 *
-	 * @param string[] $block_types Block names like 'wp:kevinbatdorf/code-block-pro'.
-	 *
-	 * @return string[] Block names to skip during DeepL translation.
+	 * Code blocks fail Gutenberg's block validation when DeepL alters the
+	 * inner HTML so it no longer matches the stored attributes.
 	 */
-	return (array) apply_filters(
-		'msls_deepl_preserve_blocks',
-		[
-			'wp:kevinbatdorf/code-block-pro',
-		]
-	);
-}
+	private const PRESERVED_BLOCK_TYPES = [
+		'wp:kevinbatdorf/code-block-pro',
+	];
 
-/**
- * Replaces preserved blocks with opaque placeholder comments.
- *
- * @param string $content   Original post content.
- * @param array  $preserved Out param. Receives the extracted block strings,
- *                          indexed by placeholder number.
- *
- * @return string Content with placeholders in place of preserved blocks.
- */
-function msls_deepl_extract_preserved_blocks( string $content, array &$preserved ): string {
-	foreach ( msls_deepl_preserved_block_types() as $block_name ) {
-		$quoted  = preg_quote( $block_name, '#' );
-		$pattern = '#<!-- ' . $quoted . '\b.*?<!-- /' . $quoted . ' -->#s';
+	/**
+	 * Replaces the default "From xx:" prefix with DeepL translation.
+	 */
+	public static function register(): void {
+		remove_filter( 'msls_quick_create_post_data', [ MslsRestApi::class, 'prefix_source_language' ] );
+		add_filter( 'msls_quick_create_post_data', [ self::class, 'translate_post_data' ], 10, 4 );
+	}
 
-		$content = preg_replace_callback(
-			$pattern,
-			function ( $matches ) use ( &$preserved ) {
-				$token       = '<!--MSLS_PRESERVE_' . count( $preserved ) . '-->';
-				$preserved[] = $matches[0];
-				return $token;
+	/**
+	 * Translates post title and content via DeepL on quick-create.
+	 *
+	 * @param array   $post_data      The post data for wp_insert_post.
+	 * @param WP_Post $source_post    The source post object.
+	 * @param int     $source_blog_id The source blog ID.
+	 * @param int     $target_blog_id The target blog ID.
+	 *
+	 * @return array
+	 */
+	public static function translate_post_data( array $post_data, WP_Post $source_post, int $source_blog_id, int $target_blog_id ): array {
+		if ( ! function_exists( 'deepl_translate' ) ) {
+			self::ensure_wpdeepl_loaded();
+		}
+
+		if ( ! function_exists( 'deepl_translate' ) ) {
+			return $post_data;
+		}
+
+		$source_lang = MslsBlogCollection::get_blog_language( $source_blog_id );
+		$target_lang = MslsBlogCollection::get_blog_language( $target_blog_id );
+
+		$source_code = strtoupper( substr( $source_lang, 0, 2 ) );
+		$target_code = strtoupper( substr( $target_lang, 0, 2 ) );
+
+		// Translate title (plain text).
+		$title_response = deepl_translate( $source_code, $target_code, [ 'post_title' => $post_data['post_title'] ] );
+
+		if ( is_array( $title_response ) && ! empty( $title_response['success'] ) && isset( $title_response['translations']['post_title'] ) ) {
+			$post_data['post_title'] = $title_response['translations']['post_title'];
+		}
+
+		// Swap blocks that must not be translated out for opaque placeholders.
+		$preserved = [];
+		$content   = self::extract_preserved_blocks( $post_data['post_content'], $preserved );
+
+		// Wrap remaining block comments so DeepL's HTML parser leaves them intact.
+		$content = preg_replace( '/<!--(.+?)-->/', '<x><!--$1--></x>', $content );
+
+		$content_response = deepl_translate( $source_code, $target_code, [ 'post_content' => $content ] );
+
+		if ( is_array( $content_response ) && ! empty( $content_response['success'] ) && isset( $content_response['translations']['post_content'] ) ) {
+			$translated_content        = $content_response['translations']['post_content'];
+			$translated_content        = preg_replace( '#<x>\s*(<!--.+?-->)\s*</x>#s', '$1', $translated_content );
+			$translated_content        = self::restore_preserved_blocks( $translated_content, $preserved );
+			$post_data['post_content'] = $translated_content;
+		}
+
+		// Re-slash: MSLS hands raw values to wp_insert_post, which wp_unslash's
+		// them and would otherwise strip backslashes from JSON block attributes.
+		return wp_slash( $post_data );
+	}
+
+	/**
+	 * Replaces preserved blocks with opaque placeholder comments.
+	 *
+	 * @param string $content   Original post content.
+	 * @param array  $preserved Out param. Receives extracted block strings.
+	 *
+	 * @return string Content with placeholders in place of preserved blocks.
+	 */
+	private static function extract_preserved_blocks( string $content, array &$preserved ): string {
+		foreach ( self::PRESERVED_BLOCK_TYPES as $block_name ) {
+			$quoted  = preg_quote( $block_name, '#' );
+			$pattern = '#<!-- ' . $quoted . '\b.*?<!-- /' . $quoted . ' -->#s';
+
+			$content = preg_replace_callback(
+				$pattern,
+				function ( $matches ) use ( &$preserved ) {
+					$token       = '<!--MSLS_PRESERVE_' . count( $preserved ) . '-->';
+					$preserved[] = $matches[0];
+					return $token;
+				},
+				$content
+			);
+		}
+		return $content;
+	}
+
+	/**
+	 * Restores previously preserved blocks from their placeholder comments.
+	 *
+	 * @param string $content   Translated content containing placeholders.
+	 * @param array  $preserved Block strings keyed by placeholder index.
+	 *
+	 * @return string Content with placeholders swapped back to original blocks.
+	 */
+	private static function restore_preserved_blocks( string $content, array $preserved ): string {
+		if ( empty( $preserved ) ) {
+			return $content;
+		}
+
+		return preg_replace_callback(
+			'/<!--MSLS_PRESERVE_(\d+)-->/',
+			function ( $matches ) use ( $preserved ) {
+				$index = (int) $matches[1];
+				return $preserved[ $index ] ?? $matches[0];
 			},
 			$content
 		);
 	}
-	return $content;
-}
 
-/**
- * Restores previously preserved blocks from their placeholder comments.
- *
- * @param string $content   Translated content containing placeholders.
- * @param array  $preserved Block strings keyed by placeholder index.
- *
- * @return string Content with placeholders swapped back to original blocks.
- */
-function msls_deepl_restore_preserved_blocks( string $content, array $preserved ): string {
-	if ( empty( $preserved ) ) {
-		return $content;
-	}
+	/**
+	 * Loads the DeepL plugin files needed for translation in REST API context.
+	 */
+	private static function ensure_wpdeepl_loaded(): void {
+		if ( function_exists( 'deepl_translate' ) ) {
+			return;
+		}
 
-	return preg_replace_callback(
-		'/<!--MSLS_PRESERVE_(\d+)-->/',
-		function ( $matches ) use ( $preserved ) {
-			$index = (int) $matches[1];
-			return $preserved[ $index ] ?? $matches[0];
-		},
-		$content
-	);
-}
+		$deepl_path = WP_PLUGIN_DIR . '/wpdeepl/';
 
-/**
- * Load the DeepL plugin files needed for translation in REST API context.
- */
-function msls_deepl_ensure_loaded(): void {
-	if ( function_exists( 'deepl_translate' ) ) {
-		return;
-	}
+		if ( ! file_exists( $deepl_path . 'wpdeepl.php' ) ) {
+			return;
+		}
 
-	$deepl_path = WP_PLUGIN_DIR . '/wpdeepl/';
+		if ( ! defined( 'WPDEEPL_DEBUG' ) ) {
+			define( 'WPDEEPL_DEBUG', false );
+		}
+		if ( ! defined( 'WPDEEPL_NAME' ) ) {
+			define( 'WPDEEPL_NAME', 'wpdeepl/wpdeepl.php' );
+		}
+		if ( ! defined( 'WPDEEPL_SLUG' ) ) {
+			define( 'WPDEEPL_SLUG', 'wpdeepl' );
+		}
+		if ( ! defined( 'WPDEEPL_PATH' ) ) {
+			define( 'WPDEEPL_PATH', realpath( $deepl_path ) );
+		}
+		if ( ! defined( 'WPDEEPL_DIR' ) ) {
+			define( 'WPDEEPL_DIR', realpath( $deepl_path ) );
+		}
+		if ( ! defined( 'WPDEEPL_URL' ) ) {
+			define( 'WPDEEPL_URL', plugins_url( '', $deepl_path . 'wpdeepl.php' ) );
+		}
 
-	if ( ! file_exists( $deepl_path . 'wpdeepl.php' ) ) {
-		return;
-	}
+		$upload_dir = wp_upload_dir();
+		if ( ! defined( 'WPDEEPL_FILES' ) ) {
+			define( 'WPDEEPL_FILES', trailingslashit( $upload_dir['basedir'] ) . 'wpdeepl' );
+		}
+		if ( ! defined( 'WPDEEPL_FILES_URL' ) ) {
+			define( 'WPDEEPL_FILES_URL', trailingslashit( $upload_dir['baseurl'] ) . 'wpdeepl' );
+		}
 
-	if ( ! defined( 'WPDEEPL_DEBUG' ) ) {
-		define( 'WPDEEPL_DEBUG', false );
-	}
-	if ( ! defined( 'WPDEEPL_NAME' ) ) {
-		define( 'WPDEEPL_NAME', 'wpdeepl/wpdeepl.php' );
-	}
-	if ( ! defined( 'WPDEEPL_SLUG' ) ) {
-		define( 'WPDEEPL_SLUG', 'wpdeepl' );
-	}
-	if ( ! defined( 'WPDEEPL_PATH' ) ) {
-		define( 'WPDEEPL_PATH', realpath( $deepl_path ) );
-	}
-	if ( ! defined( 'WPDEEPL_DIR' ) ) {
-		define( 'WPDEEPL_DIR', realpath( $deepl_path ) );
-	}
-	if ( ! defined( 'WPDEEPL_URL' ) ) {
-		define( 'WPDEEPL_URL', plugins_url( '', $deepl_path . 'wpdeepl.php' ) );
-	}
+		$wpdeepl_plugin_data = get_file_data( $deepl_path . 'wpdeepl.php', [ 'Version' => 'Version' ], false );
+		if ( ! defined( 'WPDEEPL_VERSION' ) ) {
+			define( 'WPDEEPL_VERSION', $wpdeepl_plugin_data['Version'] );
+		}
+		if ( ! defined( 'WPDEEPL_FLAVOR' ) ) {
+			define( 'WPDEEPL_FLAVOR', 'free' );
+		}
 
-	$upload_dir = wp_upload_dir();
-	if ( ! defined( 'WPDEEPL_FILES' ) ) {
-		define( 'WPDEEPL_FILES', trailingslashit( $upload_dir['basedir'] ) . 'wpdeepl' );
-	}
-	if ( ! defined( 'WPDEEPL_FILES_URL' ) ) {
-		define( 'WPDEEPL_FILES_URL', trailingslashit( $upload_dir['baseurl'] ) . 'wpdeepl' );
-	}
+		$files = [
+			'deepl-configuration.class.php',
+			'includes/deepl-functions.php',
+			'client/deepl-data.class.php',
+			'client/deeplapi.class.php',
+			'client/deeplapi-functions.php',
+			'client/deeplapi-translate.class.php',
+		];
 
-	$wpdeepl_plugin_data = get_file_data( $deepl_path . 'wpdeepl.php', [ 'Version' => 'Version' ], false );
-	if ( ! defined( 'WPDEEPL_VERSION' ) ) {
-		define( 'WPDEEPL_VERSION', $wpdeepl_plugin_data['Version'] );
-	}
-	if ( ! defined( 'WPDEEPL_FLAVOR' ) ) {
-		define( 'WPDEEPL_FLAVOR', 'free' );
-	}
-
-	$files = [
-		'deepl-configuration.class.php',
-		'includes/deepl-functions.php',
-		'client/deepl-data.class.php',
-		'client/deeplapi.class.php',
-		'client/deeplapi-functions.php',
-		'client/deeplapi-translate.class.php',
-	];
-
-	foreach ( $files as $file ) {
-		$full_path = trailingslashit( WPDEEPL_PATH ) . $file;
-		if ( file_exists( $full_path ) ) {
-			require_once $full_path;
+		foreach ( $files as $file ) {
+			$full_path = trailingslashit( WPDEEPL_PATH ) . $file;
+			if ( file_exists( $full_path ) ) {
+				require_once $full_path;
+			}
 		}
 	}
 }

--- a/web/app/mu-plugins/msls-deepl-translate.php
+++ b/web/app/mu-plugins/msls-deepl-translate.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Plugin Name: MSLS DeepL Translate
+ * Description: Translates title and content via DeepL when using MSLS quick-create.
+ */
+
+add_action( 'rest_api_init', 'msls_deepl_register_filter', 99 );
+
+/**
+ * Replace the default "From xx:" prefix with DeepL translation.
+ */
+function msls_deepl_register_filter(): void {
+	remove_filter( 'msls_quick_create_post_data', array( lloc\Msls\MslsRestApi::class, 'prefix_source_language' ) );
+	add_filter( 'msls_quick_create_post_data', 'msls_deepl_translate_post_data', 10, 4 );
+}
+
+/**
+ * Translate post title and content via DeepL on quick-create.
+ *
+ * @param array    $post_data      The post data for wp_insert_post.
+ * @param \WP_Post $source_post    The source post object.
+ * @param int      $source_blog_id The source blog ID.
+ * @param int      $target_blog_id The target blog ID.
+ *
+ * @return array
+ */
+function msls_deepl_translate_post_data( array $post_data, \WP_Post $source_post, int $source_blog_id, int $target_blog_id ): array {
+	if ( ! function_exists( 'deepl_translate' ) ) {
+		msls_deepl_ensure_loaded();
+	}
+
+	if ( ! function_exists( 'deepl_translate' ) ) {
+		return $post_data;
+	}
+
+	$source_lang = lloc\Msls\MslsBlogCollection::get_blog_language( $source_blog_id );
+	$target_lang = lloc\Msls\MslsBlogCollection::get_blog_language( $target_blog_id );
+
+	$source_code = strtoupper( substr( $source_lang, 0, 2 ) );
+	$target_code = strtoupper( substr( $target_lang, 0, 2 ) );
+
+	// Translate title (plain text).
+	$title_response = deepl_translate( $source_code, $target_code, array( 'post_title' => $post_data['post_title'] ) );
+
+	if ( is_array( $title_response ) && ! empty( $title_response['success'] ) && isset( $title_response['translations']['post_title'] ) ) {
+		$post_data['post_title'] = $title_response['translations']['post_title'];
+	}
+
+	// Translate content — wrap block comments so DeepL's HTML parser doesn't choke.
+	$content = preg_replace( '/<!--(.+?)-->/', '<x><!--$1--></x>', $post_data['post_content'] );
+
+	$content_response = deepl_translate( $source_code, $target_code, array( 'post_content' => $content ) );
+
+	if ( is_array( $content_response ) && ! empty( $content_response['success'] ) && isset( $content_response['translations']['post_content'] ) ) {
+		$translated_content = $content_response['translations']['post_content'];
+		$translated_content = preg_replace( '#<x>\s*(<!--.+?-->)\s*</x>#s', '$1', $translated_content );
+		$post_data['post_content'] = $translated_content;
+	}
+
+	return $post_data;
+}
+
+/**
+ * Load the DeepL plugin files needed for translation in REST API context.
+ */
+function msls_deepl_ensure_loaded(): void {
+	if ( function_exists( 'deepl_translate' ) ) {
+		return;
+	}
+
+	$deepl_path = WP_PLUGIN_DIR . '/wpdeepl/';
+
+	if ( ! file_exists( $deepl_path . 'wpdeepl.php' ) ) {
+		return;
+	}
+
+	if ( ! defined( 'WPDEEPL_DEBUG' ) ) {
+		define( 'WPDEEPL_DEBUG', false );
+	}
+	if ( ! defined( 'WPDEEPL_NAME' ) ) {
+		define( 'WPDEEPL_NAME', 'wpdeepl/wpdeepl.php' );
+	}
+	if ( ! defined( 'WPDEEPL_SLUG' ) ) {
+		define( 'WPDEEPL_SLUG', 'wpdeepl' );
+	}
+	if ( ! defined( 'WPDEEPL_PATH' ) ) {
+		define( 'WPDEEPL_PATH', realpath( $deepl_path ) );
+	}
+	if ( ! defined( 'WPDEEPL_DIR' ) ) {
+		define( 'WPDEEPL_DIR', realpath( $deepl_path ) );
+	}
+	if ( ! defined( 'WPDEEPL_URL' ) ) {
+		define( 'WPDEEPL_URL', plugins_url( '', $deepl_path . 'wpdeepl.php' ) );
+	}
+
+	$upload_dir = wp_upload_dir();
+	if ( ! defined( 'WPDEEPL_FILES' ) ) {
+		define( 'WPDEEPL_FILES', trailingslashit( $upload_dir['basedir'] ) . 'wpdeepl' );
+	}
+	if ( ! defined( 'WPDEEPL_FILES_URL' ) ) {
+		define( 'WPDEEPL_FILES_URL', trailingslashit( $upload_dir['baseurl'] ) . 'wpdeepl' );
+	}
+
+	$wpdeepl_plugin_data = get_file_data( $deepl_path . 'wpdeepl.php', array( 'Version' => 'Version' ), false );
+	if ( ! defined( 'WPDEEPL_VERSION' ) ) {
+		define( 'WPDEEPL_VERSION', $wpdeepl_plugin_data['Version'] );
+	}
+	if ( ! defined( 'WPDEEPL_FLAVOR' ) ) {
+		define( 'WPDEEPL_FLAVOR', 'free' );
+	}
+
+	$files = array(
+		'deepl-configuration.class.php',
+		'includes/deepl-functions.php',
+		'client/deepl-data.class.php',
+		'client/deeplapi.class.php',
+		'client/deeplapi-functions.php',
+		'client/deeplapi-translate.class.php',
+	);
+
+	foreach ( $files as $file ) {
+		$full_path = trailingslashit( WPDEEPL_PATH ) . $file;
+		if ( file_exists( $full_path ) ) {
+			include_once $full_path;
+		}
+	}
+}

--- a/web/app/mu-plugins/msls-deepl-translate.php
+++ b/web/app/mu-plugins/msls-deepl-translate.php
@@ -63,7 +63,13 @@ function msls_deepl_translate_post_data( array $post_data, \WP_Post $source_post
 		$post_data['post_content'] = $translated_content;
 	}
 
-	return $post_data;
+	// MslsRestApi::prepare_post_data() reads raw values from $source_post and
+	// hands them to wp_insert_post(), which runs wp_unslash() on its input.
+	// Without re-slashing here, every backslash in the post data is stripped —
+	// silently corrupting JSON-encoded block attributes (e.g. Code Block Pro's
+	// "code":"...\n..." becomes "code":"...n..."), which then fails Gutenberg's
+	// block validation.
+	return wp_slash( $post_data );
 }
 
 /**

--- a/web/app/mu-plugins/msls-deepl-translate.php
+++ b/web/app/mu-plugins/msls-deepl-translate.php
@@ -202,7 +202,7 @@ function msls_deepl_ensure_loaded(): void {
 	foreach ( $files as $file ) {
 		$full_path = trailingslashit( WPDEEPL_PATH ) . $file;
 		if ( file_exists( $full_path ) ) {
-			include_once $full_path;
+			require_once $full_path;
 		}
 	}
 }

--- a/web/app/mu-plugins/msls-deepl-translate.php
+++ b/web/app/mu-plugins/msls-deepl-translate.php
@@ -10,7 +10,7 @@ add_action( 'rest_api_init', 'msls_deepl_register_filter', 99 );
  * Replace the default "From xx:" prefix with DeepL translation.
  */
 function msls_deepl_register_filter(): void {
-	remove_filter( 'msls_quick_create_post_data', array( lloc\Msls\MslsRestApi::class, 'prefix_source_language' ) );
+	remove_filter( 'msls_quick_create_post_data', [ lloc\Msls\MslsRestApi::class, 'prefix_source_language' ] );
 	add_filter( 'msls_quick_create_post_data', 'msls_deepl_translate_post_data', 10, 4 );
 }
 
@@ -40,24 +40,105 @@ function msls_deepl_translate_post_data( array $post_data, \WP_Post $source_post
 	$target_code = strtoupper( substr( $target_lang, 0, 2 ) );
 
 	// Translate title (plain text).
-	$title_response = deepl_translate( $source_code, $target_code, array( 'post_title' => $post_data['post_title'] ) );
+	$title_response = deepl_translate( $source_code, $target_code, [ 'post_title' => $post_data['post_title'] ] );
 
 	if ( is_array( $title_response ) && ! empty( $title_response['success'] ) && isset( $title_response['translations']['post_title'] ) ) {
 		$post_data['post_title'] = $title_response['translations']['post_title'];
 	}
 
-	// Translate content — wrap block comments so DeepL's HTML parser doesn't choke.
-	$content = preg_replace( '/<!--(.+?)-->/', '<x><!--$1--></x>', $post_data['post_content'] );
+	// Replace blocks that must not be translated (e.g. code) with opaque
+	// placeholders, so DeepL never sees their inner HTML.
+	$preserved = [];
+	$content   = msls_deepl_extract_preserved_blocks( $post_data['post_content'], $preserved );
 
-	$content_response = deepl_translate( $source_code, $target_code, array( 'post_content' => $content ) );
+	// Wrap remaining block comments so DeepL's HTML parser leaves them intact.
+	$content = preg_replace( '/<!--(.+?)-->/', '<x><!--$1--></x>', $content );
+
+	$content_response = deepl_translate( $source_code, $target_code, [ 'post_content' => $content ] );
 
 	if ( is_array( $content_response ) && ! empty( $content_response['success'] ) && isset( $content_response['translations']['post_content'] ) ) {
 		$translated_content = $content_response['translations']['post_content'];
 		$translated_content = preg_replace( '#<x>\s*(<!--.+?-->)\s*</x>#s', '$1', $translated_content );
+		$translated_content = msls_deepl_restore_preserved_blocks( $translated_content, $preserved );
 		$post_data['post_content'] = $translated_content;
 	}
 
 	return $post_data;
+}
+
+/**
+ * Returns Gutenberg block types whose content must not be translated.
+ *
+ * Code blocks fail Gutenberg's block validation when DeepL alters the
+ * inner HTML so it no longer matches the stored attributes — Gutenberg
+ * then surfaces them as "unexpected or invalid content".
+ *
+ * @return string[] Block names like 'wp:kevinbatdorf/code-block-pro'.
+ */
+function msls_deepl_preserved_block_types(): array {
+	/**
+	 * Filters the Gutenberg block types whose content must not be translated.
+	 *
+	 * @param string[] $block_types Block names like 'wp:kevinbatdorf/code-block-pro'.
+	 *
+	 * @return string[] Block names to skip during DeepL translation.
+	 */
+	return (array) apply_filters(
+		'msls_deepl_preserve_blocks',
+		[
+			'wp:kevinbatdorf/code-block-pro',
+		]
+	);
+}
+
+/**
+ * Replaces preserved blocks with opaque placeholder comments.
+ *
+ * @param string $content   Original post content.
+ * @param array  $preserved Out param. Receives the extracted block strings,
+ *                          indexed by placeholder number.
+ *
+ * @return string Content with placeholders in place of preserved blocks.
+ */
+function msls_deepl_extract_preserved_blocks( string $content, array &$preserved ): string {
+	foreach ( msls_deepl_preserved_block_types() as $block_name ) {
+		$quoted  = preg_quote( $block_name, '#' );
+		$pattern = '#<!-- ' . $quoted . '\b.*?<!-- /' . $quoted . ' -->#s';
+
+		$content = preg_replace_callback(
+			$pattern,
+			function ( $matches ) use ( &$preserved ) {
+				$token       = '<!--MSLS_PRESERVE_' . count( $preserved ) . '-->';
+				$preserved[] = $matches[0];
+				return $token;
+			},
+			$content
+		);
+	}
+	return $content;
+}
+
+/**
+ * Restores previously preserved blocks from their placeholder comments.
+ *
+ * @param string $content   Translated content containing placeholders.
+ * @param array  $preserved Block strings keyed by placeholder index.
+ *
+ * @return string Content with placeholders swapped back to original blocks.
+ */
+function msls_deepl_restore_preserved_blocks( string $content, array $preserved ): string {
+	if ( empty( $preserved ) ) {
+		return $content;
+	}
+
+	return preg_replace_callback(
+		'/<!--MSLS_PRESERVE_(\d+)-->/',
+		function ( $matches ) use ( $preserved ) {
+			$index = (int) $matches[1];
+			return $preserved[ $index ] ?? $matches[0];
+		},
+		$content
+	);
 }
 
 /**
@@ -101,7 +182,7 @@ function msls_deepl_ensure_loaded(): void {
 		define( 'WPDEEPL_FILES_URL', trailingslashit( $upload_dir['baseurl'] ) . 'wpdeepl' );
 	}
 
-	$wpdeepl_plugin_data = get_file_data( $deepl_path . 'wpdeepl.php', array( 'Version' => 'Version' ), false );
+	$wpdeepl_plugin_data = get_file_data( $deepl_path . 'wpdeepl.php', [ 'Version' => 'Version' ], false );
 	if ( ! defined( 'WPDEEPL_VERSION' ) ) {
 		define( 'WPDEEPL_VERSION', $wpdeepl_plugin_data['Version'] );
 	}
@@ -109,14 +190,14 @@ function msls_deepl_ensure_loaded(): void {
 		define( 'WPDEEPL_FLAVOR', 'free' );
 	}
 
-	$files = array(
+	$files = [
 		'deepl-configuration.class.php',
 		'includes/deepl-functions.php',
 		'client/deepl-data.class.php',
 		'client/deeplapi.class.php',
 		'client/deeplapi-functions.php',
 		'client/deeplapi-translate.class.php',
-	);
+	];
 
 	foreach ( $files as $file ) {
 		$full_path = trailingslashit( WPDEEPL_PATH ) . $file;


### PR DESCRIPTION
## Summary

Improvements to the `msls-deepl-translate` mu-plugin (and its dependencies) so MSLS quick-create produces a clean, valid draft even when the source post contains Code Block Pro blocks.

### Commits

- **chore**: Track `lloc/multisite-language-switcher` `dev-master` so we can pick up unreleased changes/APIs.
- **chore**: Add `msls-deepl-translate.php` to git (was gitignored / dev-machine only). Without this, the mu-plugin doesn't deploy.
- **feat**: Preserve `wp:kevinbatdorf/code-block-pro` blocks (and any added via the `msls_deepl_preserve_blocks` filter) by swapping them out for opaque placeholder comments before sending content to DeepL, then restoring them after. Prevents DeepL from translating the inner `<pre><code>` HTML and desynchronising it from the stored block attributes.
- **style**: `require_once` instead of `include_once` for the wpdeepl bootstrap (the surrounding `file_exists` already handles the missing-file case). Brings the file to zero phpcs warnings.
- **fix**: `wp_slash` the post data before returning from the filter. MSLS's `prepare_post_data` reads raw values from `$source_post` and hands them to `wp_insert_post`, which silently `wp_unslash`s its input — corrupting JSON-encoded block attributes like Code Block Pro's `"code":"...\n..."`.

## Test plan
- [x] MSLS quick-create on a post with a Code Block Pro block produces a draft with the CBP block intact (no "ungültiger Inhalt" / "press update to refresh" prompts)
- [ ] MSLS quick-create on a post without CBP still translates normally
- [ ] Verify deploy runs green