### PR TITLE
chore: install translation downloader (wp.org language packs)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@
 !/web/app/uploads/.gitignore
 !/web/app/uploads/.htaccess
 
+# Languages (downloaded by inpsyde/wp-translation-downloader)
+/web/app/languages/
+
 # Environment files
 .env
 .env.*

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,8 @@
     "wpackagist-theme/twentytwentyfive": "^1.4",
     "wpackagist-plugin/redirection": "^5.7",
     "apermo/apermo-stash": "^0.2.0",
-    "apermo/apermo-notify": "^0.1.1"
+    "apermo/apermo-notify": "^0.1.1",
+    "inpsyde/wp-translation-downloader": "^2.6"
   },
   "require-dev": {
     "apermo/apermo-coding-standards": "^1.0",
@@ -74,7 +75,8 @@
     "allow-plugins": {
       "composer/installers": true,
       "roots/wordpress-core-installer": true,
-      "dealerdirect/phpcodesniffer-composer-installer": true
+      "dealerdirect/phpcodesniffer-composer-installer": true,
+      "inpsyde/wp-translation-downloader": true
     }
   },
   "minimum-stability": "dev",
@@ -85,7 +87,11 @@
       "web/app/plugins/{$name}/": ["type:wordpress-plugin"],
       "web/app/themes/{$name}/": ["type:wordpress-theme"]
     },
-    "wordpress-install-dir": "web/wp"
+    "wordpress-install-dir": "web/wp",
+    "wp-translation-downloader": {
+      "languages": ["de_DE"],
+      "directory": "web/app/languages"
+    }
   },
   "scripts": {
     "test": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9b152964bad73eafb572830d87a1ca7f",
+    "content-hash": "786e3fda317708588a249282df8c5d17",
     "packages": [
         {
             "name": "apermo/apermo-notify",
@@ -354,6 +354,68 @@
                 }
             ],
             "time": "2025-12-27T19:43:20+00:00"
+        },
+        {
+            "name": "inpsyde/wp-translation-downloader",
+            "version": "2.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/inpsyde/wp-translation-downloader.git",
+                "reference": "60c4a8092d5e0feca2bd8b62c645257fc3bff12e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/inpsyde/wp-translation-downloader/zipball/60c4a8092d5e0feca2bd8b62c645257fc3bff12e",
+                "reference": "60c4a8092d5e0feca2bd8b62c645257fc3bff12e",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^2.0",
+                "composer/installers": "^1.0 || ^2.0",
+                "ext-json": "*",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "behat/behat": "^v3.10.0",
+                "brain/monkey": "^2.6.1",
+                "composer/composer": "^2.3.7",
+                "inpsyde/php-coding-standards": "^1.0.0",
+                "mikey179/vfsstream": "^v1.6.10",
+                "ondram/ci-detector": "^4.1.0",
+                "phpunit/phpunit": "^9.6.0",
+                "vimeo/psalm": "^4.23.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Inpsyde\\WpTranslationDownloader\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Inpsyde\\WpTranslationDownloader\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Syde GmbH",
+                    "email": "hello@syde.com",
+                    "homepage": "https://syde.com/",
+                    "role": "Company"
+                },
+                {
+                    "name": "Christian Leucht",
+                    "email": "c.leucht@inpsyde.com"
+                }
+            ],
+            "description": "Composer plugin to download translations from wordpress.org API.",
+            "support": {
+                "issues": "https://github.com/inpsyde/wp-translation-downloader/issues",
+                "source": "https://github.com/inpsyde/wp-translation-downloader/tree/2.6"
+            },
+            "time": "2025-05-28T12:02:26+00:00"
         },
         {
             "name": "lloc/multisite-language-switcher",

--- a/wp-translation-downloader.lock
+++ b/wp-translation-downloader.lock
@@ -1,0 +1,170 @@
+{
+    "multisite-language-switcher": {
+        "translations": {
+            "de_DE": {
+                "updated": "2025-07-19 20:06:51",
+                "version": "2.10.1"
+            }
+        }
+    },
+    "wordpress-no-content": {
+        "translations": {
+            "de_DE": {
+                "updated": "2026-05-25 01:04:07",
+                "version": "7.0"
+            }
+        }
+    },
+    "activitypub": {
+        "translations": {
+            "de_DE": {
+                "updated": "2026-03-02 22:15:42",
+                "version": "7.9.1"
+            }
+        }
+    },
+    "antispam-bee": {
+        "translations": {
+            "de_DE": {
+                "updated": "2024-08-23 17:47:01",
+                "version": "2.11.11"
+            }
+        }
+    },
+    "cachify": {
+        "translations": {
+            "de_DE": {
+                "updated": "2025-06-22 08:51:48",
+                "version": "2.4.2"
+            }
+        }
+    },
+    "contact-form-7": {
+        "translations": {
+            "de_DE": {
+                "updated": "2026-04-05 02:28:42",
+                "version": "6.1.6"
+            }
+        }
+    },
+    "dominant-color-images": {
+        "translations": {
+            "de_DE": {
+                "updated": "2025-04-08 17:05:22",
+                "version": "1.2.1"
+            }
+        }
+    },
+    "duplicate-post": {
+        "translations": {
+            "de_DE": {
+                "updated": "2026-03-09 12:12:05",
+                "version": "4.6"
+            }
+        }
+    },
+    "embed-privacy": {
+        "translations": {
+            "de_DE": {
+                "updated": "2026-02-16 15:11:57",
+                "version": "1.12.4"
+            }
+        }
+    },
+    "friends": {
+        "translations": {
+            "de_DE": {
+                "updated": "2026-03-17 18:48:25",
+                "version": "3.6.0"
+            }
+        }
+    },
+    "gatherpress": {
+        "translations": {
+            "de_DE": {
+                "updated": "2025-11-01 14:05:44",
+                "version": "0.32.3"
+            }
+        }
+    },
+    "hum": {
+        "translations": {
+            "de_DE": {
+                "updated": "2025-12-29 18:16:15",
+                "version": "1.3.6"
+            }
+        }
+    },
+    "individual-multisite-author": {
+        "translations": {
+            "de_DE": {
+                "updated": "2024-01-25 15:51:14",
+                "version": "1.4.0"
+            }
+        }
+    },
+    "performance-lab": {
+        "translations": {
+            "de_DE": {
+                "updated": "2026-05-12 15:39:43",
+                "version": "4.1.0"
+            }
+        }
+    },
+    "redirection": {
+        "translations": {
+            "de_DE": {
+                "updated": "2026-03-28 18:03:37",
+                "version": "5.7.5"
+            }
+        }
+    },
+    "speculation-rules": {
+        "translations": {
+            "de_DE": {
+                "updated": "2025-04-08 20:57:19",
+                "version": "1.6.0"
+            }
+        }
+    },
+    "two-factor": {
+        "translations": {
+            "de_DE": {
+                "updated": "2025-11-15 01:56:46",
+                "version": "0.14.2"
+            }
+        }
+    },
+    "webp-uploads": {
+        "translations": {
+            "de_DE": {
+                "updated": "2025-01-27 23:38:54",
+                "version": "2.6.1"
+            }
+        }
+    },
+    "wordpress-seo": {
+        "translations": {
+            "de_DE": {
+                "updated": "2026-02-11 21:11:41",
+                "version": "26.9"
+            }
+        }
+    },
+    "wp-force-login": {
+        "translations": {
+            "de_DE": {
+                "updated": "2025-01-25 21:23:31",
+                "version": "5.6.3"
+            }
+        }
+    },
+    "twentytwentyfive": {
+        "translations": {
+            "de_DE": {
+                "updated": "2026-04-26 00:57:42",
+                "version": "1.5"
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds [`inpsyde/wp-translation-downloader`](https://github.com/inpsyde/wp-translation-downloader) to pull de_DE language packs from translate.wordpress.org during `composer install`, covering WordPress core and every Composer-managed plugin/theme.

Fixes the wp-admin notice _"No language files are currently installed."_ that appeared on every site after the cutover.

## Changes

- `composer require inpsyde/wp-translation-downloader` (allowed as a plugin in `config.allow-plugins`)
- `extra.wp-translation-downloader` config in `composer.json`:
  - `languages: ["de_DE"]` — en_US is the default and ships with WP core, no download needed
  - `directory: "web/app/languages"` — Bedrock's content path
- `web/app/languages/` added to `.gitignore` (now Composer-managed, repopulated in CI on every build)
- `wp-translation-downloader.lock` committed (pins the specific translation versions for reproducible builds)

## Local run results

```
Overall stats:
 - 31 packages processed
 - 21 translations downloaded
 - 0 translations locked
 - 0 translations failed
```

## Test plan
- [ ] CI green
- [ ] After deploy, `web/app/languages/` exists on prod with de_DE files
- [ ] No "No language files are currently installed" notice in wp-admin on any site
- [ ] German admin UI renders correctly on de_DE sites