### PR TITLE
chore: add Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":dependencyDashboard",
+    ":semanticCommitTypeAll(chore)"
+  ],
+  "schedule": ["before 06:00 on monday"],
+  "timezone": "Europe/Berlin",
+  "labels": ["dependencies"],
+  "rangeStrategy": "bump",
+  "packageRules": [
+    {
+      "matchManagers": ["composer"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "Composer minor + patch"
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub Actions"
+    },
+    {
+      "matchPackageNames": ["roave/security-advisories"],
+      "enabled": false
+    }
+  ]
+}

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,7 +5,7 @@
     ":dependencyDashboard",
     ":semanticCommitTypeAll(chore)"
   ],
-  "schedule": ["before 06:00 on monday"],
+  "schedule": ["before 06:00"],
   "timezone": "Europe/Berlin",
   "labels": ["dependencies"],
   "rangeStrategy": "bump",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -22,6 +22,11 @@
     {
       "matchPackageNames": ["roave/security-advisories"],
       "enabled": false
+    },
+    {
+      "matchPackageNames": ["roots/wordpress", "roots/wordpress-no-content"],
+      "groupName": "WordPress {{newMajor}}.{{newMinor}}",
+      "labels": ["dependencies", "wordpress-core"]
     }
   ]
 }

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "oscarotero/env": "^2.1",
     "roots/bedrock-autoloader": "^1.0",
     "roots/bedrock-disallow-indexing": "^2.0",
-    "roots/wordpress": "^7.0",
+    "roots/wordpress": "7.*",
     "roots/wp-config": "^1.0",
     "apermo/sovereignty": "1.0.0",
     "wpackagist-plugin/activitypub": "^7.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "786e3fda317708588a249282df8c5d17",
+    "content-hash": "4ba3c58bbae156a46d02d86c26c05553",
     "packages": [
         {
             "name": "apermo/apermo-notify",


### PR DESCRIPTION
## Summary

Configures Renovate to keep Composer dependencies and GitHub Actions versions current via weekly PRs.

## Config

- **Schedule**: Monday before 06:00 Europe/Berlin — once a week, batched.
- **Composer (minor + patch)**: grouped into a single weekly PR.
- **Composer (major)**: one PR per package — major bumps tend to be breaking and benefit from individual review.
- **GitHub Actions**: grouped into one PR.
- **Excluded**: `roave/security-advisories` (it's `dev-latest`, constantly changing — would generate noise).
- **Commit prefix**: `chore(deps): …` (extends `:semanticCommitTypeAll(chore)`), matches the project's Conventional Commits style.
- **Dependency Dashboard**: an open issue listing all pending updates with one-click "rebase" / "force re-create" actions.

## After merging

You'll need to enable the Renovate GitHub App on `apermo/chrdm.de` (if not already on the org). Once installed, it'll pick up `.github/renovate.json` automatically and post an initial "Configure Renovate" onboarding PR.

## Translations

Renovate-driven plugin bumps will refresh translations automatically:

1. Renovate opens PR bumping e.g. `wpackagist-plugin/foo` v1.2 → v1.3.
2. CI is green (only validates PHP syntax + composer audit).
3. You merge → push to main triggers Deploy.
4. Deploy's `composer install` runs `inpsyde/wp-translation-downloader`, which sees the new plugin version and downloads the matching translation pack into `web/app/languages/`.
5. rsync ships the refreshed `web/app/languages/` to prod.

Because `wp-translation-downloader.lock` is gitignored, every deploy gets the latest translation packs available on translate.wordpress.org for every installed package — Renovate doesn't need to manage translations itself.

The one gap: translations that get *updated upstream without any plugin version bump* won't be pulled until **some** other deploy runs. If that becomes an issue we can add a weekly scheduled workflow that triggers `Deploy` purely to refresh translations.

## Test plan
- [ ] CI green
- [ ] After merge: install/enable Renovate app on the repo
- [ ] First Renovate onboarding PR appears within a few minutes
- [ ] Next Monday: first batched update PR appears