### PR TITLE
chore: build sovereignty CSS in deploy workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
         run: composer install --prefer-dist
 
       - name: Check PHP syntax
-        run: find config web/app -name "*.php" -print0 | xargs -0 -n1 php -l
+        run: git ls-files -z '*.php' | xargs -0 -n1 -P 4 php -l
 
   security:
     name: Security Check

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,6 +41,11 @@ jobs:
       - name: Install Composer dependencies
         run: composer install --no-dev --optimize-autoloader --prefer-dist
 
+      - name: Build sovereignty theme assets
+        uses: apermo/sovereignty/.github/actions/build@v1.4.1
+        with:
+          working-directory: web/app/themes/sovereignty
+
       - name: Upload build artifact
         uses: actions/upload-artifact@v7
         with:

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "roots/bedrock-disallow-indexing": "^2.0",
     "roots/wordpress": "7.*",
     "roots/wp-config": "^1.0",
-    "apermo/sovereignty": "1.0.0",
+    "apermo/sovereignty": "^1.4.1",
     "wpackagist-plugin/activitypub": "^7.8",
     "wpackagist-plugin/antispam-bee": "^2.11",
     "wpackagist-plugin/basepress": "^2.17",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4ba3c58bbae156a46d02d86c26c05553",
+    "content-hash": "250dcc8dd3587aa3ab90e33658f220db",
     "packages": [
         {
             "name": "apermo/apermo-notify",
@@ -107,25 +107,80 @@
         },
         {
             "name": "apermo/sovereignty",
-            "version": "v1.0.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/apermo/sovereignty.git",
-                "reference": "7f4cfd5d4e9d4099965183507a94997324c32fb3"
+                "reference": "08f446017941f8cabcc8c779f99183ba9f35ddba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/apermo/sovereignty/zipball/7f4cfd5d4e9d4099965183507a94997324c32fb3",
-                "reference": "7f4cfd5d4e9d4099965183507a94997324c32fb3",
+                "url": "https://api.github.com/repos/apermo/sovereignty/zipball/08f446017941f8cabcc8c779f99183ba9f35ddba",
+                "reference": "08f446017941f8cabcc8c779f99183ba9f35ddba",
                 "shasum": ""
             },
             "require": {
-                "composer/installers": "~2.2",
-                "php": ">=7.4.0"
+                "composer/installers": "^2.2",
+                "php": ">=8.3"
+            },
+            "require-dev": {
+                "apermo/apermo-coding-standards": "^2.6.2",
+                "apermo/phpstan-wordpress-rules": "^0.2",
+                "brain/monkey": "^2.6",
+                "pfefferle/wordpress-activitypub": "^8.0",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^11.0",
+                "roave/security-advisories": "dev-latest",
+                "szepeviktor/phpstan-wordpress": "^2.0",
+                "wpackagist-plugin/indieweb-post-kinds": "*",
+                "wpackagist-plugin/pwa": "*",
+                "yoast/phpunit-polyfills": "^3.0",
+                "yoast/wordpress-seo": "^27.2"
             },
             "type": "wordpress-theme",
             "extra": {
-                "installer-name": "sovereignty"
+                "installer-name": "sovereignty",
+                "installer-paths": {
+                    "vendor/{$vendor}/{$name}/": [
+                        "type:wordpress-plugin"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Apermo\\Sovereignty\\": "src/"
+                }
+            },
+            "scripts": {
+                "cs": [
+                    "phpcs --warning-severity=0"
+                ],
+                "cs:fix": [
+                    "phpcbf"
+                ],
+                "lint": [
+                    "@cs"
+                ],
+                "lint:fix": [
+                    "@cs:fix"
+                ],
+                "test": [
+                    "phpunit"
+                ],
+                "test:unit": [
+                    "phpunit --testsuite Unit"
+                ],
+                "test:integration": [
+                    "phpunit --testsuite Integration"
+                ],
+                "analyse": [
+                    "phpstan analyse -c phpstan.neon.dist --memory-limit=2G"
+                ],
+                "analyse:strict": [
+                    "phpstan analyse -c phpstan-strict.neon --memory-limit=2G"
+                ]
             },
             "license": [
                 "MIT"
@@ -141,11 +196,12 @@
                 }
             ],
             "description": "Pure Zen - Fork of Pfefferle's Autonomie Theme",
+            "homepage": "https://github.com/apermo/sovereignty",
             "support": {
-                "source": "https://github.com/apermo/sovereignty/tree/v1.0.0",
-                "issues": "https://github.com/apermo/sovereignty/issues"
+                "issues": "https://github.com/apermo/sovereignty/issues",
+                "source": "https://github.com/apermo/sovereignty"
             },
-            "time": "2026-01-27T21:59:40+00:00"
+            "time": "2026-05-25T20:26:30+00:00"
         },
         {
             "name": "composer/installers",


### PR DESCRIPTION
## Summary

Closes #14.

Sovereignty 1.4.1 stops shipping compiled CSS in its Composer dist archive (`style.css` untracked, `assets/css/*.css` already gitignored). Without an explicit build step, the deploy would ship the theme without any compiled stylesheets and WordPress would refuse to recognise it.

Two changes:

1. **`composer.json`**: bump `apermo/sovereignty` from `1.0.0` → `^1.4.1`. The Post_Format::get_format_link fatal that prompted the earlier downgrade is fixed in 1.4.1 (apermo/sovereignty#78).
2. **`.github/workflows/deploy.yml`**: insert the upstream reusable build action between `composer install` and the artifact upload — sets up Node, runs `npm ci`, runs `npm run build` inside `web/app/themes/sovereignty/`. Compiled CSS lands in the workspace and is included in the existing rsync.

## Test plan
- [x] CI green (`Validate` + `Security Check`)
- [ ] After merge: Deploy workflow completes, including the new "Build sovereignty theme assets" step
- [ ] Deployed theme directory contains `style.css`, `style.min.css`, and `assets/css/*.css` (narrow / default / wide / print / editor-style)
- [ ] WordPress admin shows the theme active without warnings
- [ ] Frontend renders with correct responsive stylesheets at narrow, default, and wide breakpoints