### PR TITLE
ci: tag-based deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy
 on:
   push:
     tags:
-      - 'v*'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,8 +2,8 @@ name: Deploy
 
 on:
   push:
-    branches:
-      - main
+    tags:
+      - 'v*'
   workflow_dispatch:
 
 concurrency:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,9 +161,22 @@ Copy `.env.example` to `.env` and configure:
 
 ### Deployment Process
 
-1. Push to `main` branch triggers deployment
-2. GitHub Actions runs `composer install` (installs WP core, themes, plugins)
-3. rsync deploys to production server
+Deploys are triggered by pushing a tag matching `v*` (or via manual
+`workflow_dispatch` on the Deploy workflow). Merges to `main` do **not**
+trigger a deploy — multiple PRs can accumulate before a release.
+
+Example release using SemVer (`vMAJOR.MINOR.PATCH`):
+
+```bash
+git tag v1.2.3 -m "release notes"
+git push --tags
+```
+
+On a tag push (or manual dispatch):
+
+1. GitHub Actions runs `composer install` (installs WP core, themes, plugins)
+2. Sovereignty theme assets are built via the upstream composite action
+3. rsync deploys to the production server
 4. Files excluded from sync: `.env`, `web/app/uploads/`, `web/.htaccess`
 
 ### cPanel Document Root


### PR DESCRIPTION
## Summary

Decouples merge-to-main from production deploy. With Renovate now batching daily dep update PRs, every-merge deploys would waste CI minutes and add unnecessary churn on the server.

## Changes

- `.github/workflows/deploy.yml` — trigger changes from `push: branches: [main]` to `push: tags: ['v*']`. `workflow_dispatch` still works for manual deploys.
- `CLAUDE.md` — documents the new release flow.

## New flow

```bash
# many small PRs merge into main throughout the week
# … no deploys triggered …

# when ready to ship:
git tag v1.2.3 -m "release notes"
git push --tags
# → Deploy workflow fires on the tag push
```

Tag scheme is SemVer (`vMAJOR.MINOR.PATCH`).

## Test plan
- [ ] CI green on this PR
- [ ] After merge: subsequent merges to main do NOT trigger Deploy
- [ ] Pushing a `v*` tag triggers Deploy
- [ ] `workflow_dispatch` from the Actions UI still works