### PR TITLE
chore: Renovate update-lockfile range strategy

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,7 +8,7 @@
   "schedule": ["before 06:00"],
   "timezone": "Europe/Berlin",
   "labels": ["dependencies"],
-  "rangeStrategy": "bump",
+  "rangeStrategy": "update-lockfile",
   "packageRules": [
     {
       "matchManagers": ["composer"],


### PR DESCRIPTION
## Summary

Switches `rangeStrategy` in `.github/renovate.json` from `bump` to `update-lockfile`. Renovate will only touch `composer.lock` for in-range version updates; `composer.json` constraints stay untouched.

## Why

`composer.lock` is already the source of truth for this application — `composer install` reads it verbatim, the version installed in CI matches the locked version exactly. The constraints in `composer.json` only define the _acceptable range_ for future resolutions. Bumping the lower bound of `^2.11` to `^2.11.11` every time a patch lands changes nothing about what's installed; it just produces a large diff that has to be reviewed and merged.

For a library that publishes to other consumers, the lower bound matters and `bump` is appropriate. For a deploy-and-forget application like this one, it's noise.

## Effects

- Renovate PRs become much smaller — typically a handful of lockfile entries instead of a constraint bump for every package.
- The `php >=8.3` → `>=8.5.6` bump that's currently failing #17's CI will stop happening — the PHP constraint won't move on its own. Once this lands, Renovate will rebase #17 with a fresh lockfile.
- Major bumps (out-of-range) still get their own dedicated PRs with the constraint widening, unchanged.

## Test plan
- [ ] CI green on this PR
- [ ] After merge: Renovate rebases #17, the resulting diff is lockfile-only, CI on #17 turns green