### PR TITLE
chore(deps): batch update — supersedes #18–#23

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,7 +42,7 @@ jobs:
         run: composer install --no-dev --optimize-autoloader --prefer-dist
 
       - name: Build sovereignty theme assets
-        uses: apermo/sovereignty/.github/actions/build@v1.4.1
+        uses: apermo/sovereignty/.github/actions/build@v1.4.2
         with:
           working-directory: web/app/themes/sovereignty
 
@@ -70,7 +70,7 @@ jobs:
           path: build
 
       - name: Deploy via rsync
-        uses: burnett01/rsync-deployments@7.0.1
+        uses: burnett01/rsync-deployments@8.0.5
         with:
           switches: -avzr --delete --exclude='.env' --exclude='web/app/uploads/' --exclude='web/.htaccess'
           path: build/
@@ -81,7 +81,7 @@ jobs:
           remote_port: ${{ secrets.DEPLOY_PORT }}
 
       - name: Clear cache on server
-        uses: appleboy/ssh-action@v1.0.3
+        uses: appleboy/ssh-action@v1.2.5
         with:
           host: ${{ secrets.DEPLOY_HOST }}
           username: ${{ secrets.DEPLOY_USER }}

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
     "inpsyde/wp-translation-downloader": "^2.6"
   },
   "require-dev": {
-    "apermo/apermo-coding-standards": "^1.0",
+    "apermo/apermo-coding-standards": "^3.0",
     "roave/security-advisories": "dev-latest"
   },
   "repositories": [

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
     "wpackagist-plugin/two-factor": "^0.16",
     "wpackagist-plugin/wp-test-email": "^1.1",
     "wpackagist-plugin/duplicate-post": "^4.5",
-    "wpackagist-plugin/wordpress-seo": "^26.8",
+    "wpackagist-plugin/wordpress-seo": "^27.0",
     "wpackagist-plugin/when-last-login": "^1.2",
     "wpackagist-theme/twentytwentyfive": "^1.4",
     "wpackagist-plugin/redirection": "^5.7",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "roots/wordpress": "7.*",
     "roots/wp-config": "^1.0",
     "apermo/sovereignty": "^1.4.1",
-    "wpackagist-plugin/activitypub": "^7.8",
+    "wpackagist-plugin/activitypub": "^8.0",
     "wpackagist-plugin/antispam-bee": "^2.11",
     "wpackagist-plugin/basepress": "^2.17",
     "wpackagist-plugin/cachify": "^2.4",

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "wpackagist-plugin/contact-form-7": "^6.1",
     "wpackagist-plugin/embed-privacy": "^1.12",
     "wpackagist-plugin/wp-force-login": "^5.6",
-    "wpackagist-plugin/friends": "^3.6",
+    "wpackagist-plugin/friends": "^4.0",
     "wpackagist-plugin/gatherpress": "^0.33",
     "wpackagist-plugin/hum": "^1.3",
     "wpackagist-plugin/dominant-color-images": "^1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "570bfd4e6bcf9728655f56efa680a5e1",
+    "content-hash": "f5f7ef41c801ba0b867ed64a1e972e00",
     "packages": [
         {
             "name": "apermo/apermo-notify",
@@ -1535,15 +1535,15 @@
         },
         {
             "name": "wpackagist-plugin/friends",
-            "version": "3.6.0",
+            "version": "4.1.0",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/friends/",
-                "reference": "tags/3.6.0"
+                "reference": "tags/4.1.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/friends.3.6.0.zip"
+                "url": "https://downloads.wordpress.org/plugin/friends.4.1.0.zip"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "429e334cdf69145e3a6271eb49888c76",
+    "content-hash": "8e751f01b47238648bd1faa9e102913d",
     "packages": [
         {
             "name": "apermo/apermo-notify",
@@ -1843,21 +1843,22 @@
     "packages-dev": [
         {
             "name": "apermo/apermo-coding-standards",
-            "version": "1.4.0",
+            "version": "v3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/apermo/apermo-coding-standards.git",
-                "reference": "6c24dc9d51f3d800d741646147a44a79d87f5535"
+                "reference": "61f264eb411bb1a4ca581ca6c60740426596a85e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/apermo/apermo-coding-standards/zipball/6c24dc9d51f3d800d741646147a44a79d87f5535",
-                "reference": "6c24dc9d51f3d800d741646147a44a79d87f5535",
+                "url": "https://api.github.com/repos/apermo/apermo-coding-standards/zipball/61f264eb411bb1a4ca581ca6c60740426596a85e",
+                "reference": "61f264eb411bb1a4ca581ca6c60740426596a85e",
                 "shasum": ""
             },
             "require": {
+                "automattic/vipwpcs": "^3.0",
                 "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
-                "php": ">=8.3",
+                "php": ">=7.4",
                 "phpcompatibility/phpcompatibility-wp": "^2.1",
                 "slevomat/coding-standard": "^8.0",
                 "squizlabs/php_codesniffer": "^3.10",
@@ -1865,12 +1866,28 @@
                 "yoast/yoastcs": "^3.0"
             },
             "require-dev": {
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
                 "phpunit/phpunit": "^11.0"
             },
             "type": "phpcodesniffer-standard",
+            "autoload": {
+                "files": [
+                    "Apermo/polyfills.php"
+                ]
+            },
             "scripts": {
                 "test": [
                     "phpunit"
+                ],
+                "analyse": [
+                    "phpstan analyse"
+                ],
+                "post-install-cmd": [
+                    "git config core.hooksPath .githooks || true"
+                ],
+                "post-update-cmd": [
+                    "git config core.hooksPath .githooks || true"
                 ]
             },
             "license": [
@@ -1894,7 +1911,7 @@
                 "issues": "https://github.com/apermo/apermo-coding-standards/issues",
                 "source": "https://github.com/apermo/apermo-coding-standards"
             },
-            "time": "2026-02-20T07:45:04+00:00"
+            "time": "2026-05-02T12:32:03+00:00"
         },
         {
             "name": "automattic/vipwpcs",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8e751f01b47238648bd1faa9e102913d",
+    "content-hash": "570bfd4e6bcf9728655f56efa680a5e1",
     "packages": [
         {
             "name": "apermo/apermo-notify",
@@ -1373,15 +1373,15 @@
         },
         {
             "name": "wpackagist-plugin/activitypub",
-            "version": "7.9.1",
+            "version": "8.3.0",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/activitypub/",
-                "reference": "tags/7.9.1"
+                "reference": "tags/8.3.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/activitypub.7.9.1.zip"
+                "url": "https://downloads.wordpress.org/plugin/activitypub.8.3.0.zip"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f5f7ef41c801ba0b867ed64a1e972e00",
+    "content-hash": "d922dd7283f34703d699b339247e2050",
     "packages": [
         {
             "name": "apermo/apermo-notify",
@@ -1751,15 +1751,15 @@
         },
         {
             "name": "wpackagist-plugin/wordpress-seo",
-            "version": "26.9",
+            "version": "27.6",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/wordpress-seo/",
-                "reference": "tags/26.9"
+                "reference": "tags/27.6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/wordpress-seo.26.9.zip"
+                "url": "https://downloads.wordpress.org/plugin/wordpress-seo.27.6.zip"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"


### PR DESCRIPTION
## Summary

Combines all six open Renovate PRs into one to cut review/merge noise. Closes #18, #19, #20, #21, #22, #23.

## Atomic commits (one per package / topic)

| Commit | Change |
|---|---|
| `chore(deps): update apermo/apermo-coding-standards to v3` | dev-dep, supersedes #20 |
| `chore(deps): update wpackagist-plugin/activitypub to v8` | supersedes #21 |
| `chore(deps): update wpackagist-plugin/friends to v4` | supersedes #22 |
| `chore(deps): update wpackagist-plugin/wordpress-seo to v27` | supersedes #23 |
| `chore(deps): update GitHub Actions in deploy workflow` | supersedes #18, #19; sovereignty action v1.4.2 also drops the Node 20 deprecation warning (apermo/sovereignty#82) |

## Risk notes

- **apermo-coding-standards v3**: dev-only, new sniff rules may surface phpcs warnings locally but CI does not run phpcs, so nothing is blocked. `composer test` may need a phpcbf pass afterwards.
- **WordPress-SEO 27.x**: Yoast majors sometimes change schema/options. Skim their release notes before tagging the release that ships this.
- **ActivityPub 8.x / Friends 4.x**: active fediverse plugins; behaviour around mention discovery and follow-handling has changed across these majors.
- **rsync-deployments v8**: action internals changed; same `with:` shape, verify the deploy job once a `v*.*.*` tag is pushed.

## Test plan
- [ ] CI green on this PR (`Validate` + `Security Check`)
- [ ] Skim release notes for wordpress-seo, activitypub, friends before tagging
- [ ] Tag `v1.x.y` after merge to actually deploy and watch for the rsync-action / sovereignty-build-action run