### PR TITLE
chore(deps): add performant-translations plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,8 @@
     "apermo/apermo-stash": "^0.2.0",
     "apermo/apermo-notify": "^0.1.1",
     "inpsyde/wp-translation-downloader": "^2.6",
-    "wpackagist-plugin/statify": "^1.8"
+    "wpackagist-plugin/statify": "^1.8",
+    "wpackagist-plugin/performant-translations": "^1.2"
   },
   "require-dev": {
     "apermo/apermo-coding-standards": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6483da4be47743a1eac7f2c718571cce",
+    "content-hash": "acad2728bfc4211e7c21577d8288a588",
     "packages": [
         {
             "name": "apermo/apermo-notify",
@@ -1640,6 +1640,24 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/performance-lab/"
+        },
+        {
+            "name": "wpackagist-plugin/performant-translations",
+            "version": "1.2.0",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/performant-translations/",
+                "reference": "tags/1.2.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/performant-translations.1.2.0.zip"
+            },
+            "require": {
+                "composer/installers": "^1.0 || ^2.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/performant-translations/"
         },
         {
             "name": "wpackagist-plugin/progress-planner",


### PR DESCRIPTION
## Summary
- Adds [Performant Translations](https://wordpress.org/plugins/performant-translations/) (`wpackagist-plugin/performant-translations` ^1.2) via Composer.

## Test plan
- [ ] `composer install` succeeds
- [ ] Plugin appears in `web/app/plugins/performant-translations/`
- [ ] Activate network-wide and verify translations still load on `christoph-daum.de`