### PR TITLE
chore(deploy): harden permissions and make rsync crash-safe

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Deploy via rsync
         uses: burnett01/rsync-deployments@8.0.5
         with:
-          switches: -avzr --delay-updates --delete-delay --exclude='.env' --exclude='web/app/uploads/' --exclude='web/.htaccess'
+          switches: -avzr --delay-updates --delete-delay --chmod=D755,F644 --exclude='.env' --exclude='web/app/uploads/' --exclude='web/.htaccess'
           path: build/
           remote_path: ${{ secrets.DEPLOY_PATH }}
           remote_host: ${{ secrets.DEPLOY_HOST }}
@@ -89,6 +89,9 @@ jobs:
           port: ${{ secrets.DEPLOY_PORT }}
           script: |
             cd ${{ secrets.DEPLOY_PATH }}
+            if [ -f ".env" ]; then
+              chmod 600 .env
+            fi
             if [ -d "web/app/cache" ]; then
               rm -rf web/app/cache/*
             fi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Deploy via rsync
         uses: burnett01/rsync-deployments@8.0.5
         with:
-          switches: -avzr --delete --exclude='.env' --exclude='web/app/uploads/' --exclude='web/.htaccess'
+          switches: -avzr --delay-updates --delete-delay --exclude='.env' --exclude='web/app/uploads/' --exclude='web/.htaccess'
           path: build/
           remote_path: ${{ secrets.DEPLOY_PATH }}
           remote_host: ${{ secrets.DEPLOY_HOST }}


### PR DESCRIPTION
Hardens the production deploy on two fronts. Both changes touch the rsync
`switches` line in `.github/workflows/deploy.yml`, so they ship together.

## `chore(deploy): harden file permissions on deploy` (#29)

- `--chmod=D755,F644` → every synced dir lands `755`, every file `644`,
  deterministically (the artifact round-trip doesn't reliably preserve POSIX
  bits) — nothing group/world-writable.
- `chmod 600 .env` in the post-deploy SSH step. `.env` holds DB credentials +
  auth salts, is excluded from rsync, and persists on the server, so it needs
  the SSH step. Guarded with `-f` so a missing `.env` never fails the deploy.

## `chore(deploy): make rsync crash-safe and near-atomic` (#30)

- `--delay-updates` → changed files are staged and renamed into place in a
  sub-second batch at the *end*, collapsing the half-old/half-new window. The
  main win: an interrupted sync discards the staged files and **leaves the live
  tree untouched** — no more half-broken deploys.
- `--delete` → `--delete-delay` so deletions apply *after* the transfer, never
  leaving a file missing mid-sync.

Out of scope (documented in the issues): recursive `uploads/` chmod, maintenance
mode, opcache reset (not reliably possible from CLI on cPanel), and the full
atomic release-dir symlink swap.

## Verification

- `actionlint` passes on the changed lines (only a pre-existing SC2086 nit on
  line 31 remains, untouched here).
- The workflow only runs on a `v*` tag / manual dispatch, so it can't be
  exercised by this merge. Validate on the next release: watch the rsync log,
  then on the server confirm
  `find web -maxdepth 3 -type f ! -perm 644` and
  `find web -maxdepth 3 -type d ! -perm 755` are empty, and
  `stat -c '%a' .env` is `600`.

Closes #29
Closes #30
