### PR TITLE
chore(deploy): lock deployed code tree read-only

### DIFF
--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -33,10 +33,16 @@ parties, no cookie banner. This is enforced by the stack (`statify`, `embed-priv
 - The deploy is tag-triggered (tags matching `v[0-9]+.[0-9]+.[0-9]+`) or manual dispatch; merges
   to `main` do **not** deploy. Flag changes that would auto-deploy on push, or that loosen the
   tag pattern to fire on non-release tags.
-- The deploy syncs with `--chmod=D755,F644` and tightens `.env` to `600`. Flag changes that
-  broaden writable paths without justification, or that would let rsync `--delete` wipe runtime
-  state (uploads, caches). (A stricter read-only lockdown of the code tree — `555`/`444` with
-  only `web/app/uploads/` writable — is proposed in PR #34; update this section when it lands.)
+- The deploy runs **unlock → rsync → lock**: a pre-rsync step re-adds owner write (`chmod u+w`)
+  to the code-tree dirs that the previous deploy locked to `555` so rsync can write; rsync syncs
+  with a transient `--chmod=D755,F644`; a post-rsync step then locks the tree back down to `555`
+  dirs / `444` files. Only `web/app/uploads/` stays writable (`755`/`644`) and `.env` is tightened
+  to `600`. Flag changes that drop the unlock or lock step, broaden writable paths beyond
+  `uploads/` without justification, or that would let rsync `--delete` wipe runtime state
+  (uploads, caches).
+- Known trade-off: with the code tree (including `web/`) at `555`, WordPress cannot rewrite
+  `web/.htaccess` at runtime (e.g. on a permalink change) — that needs a manual unlock. Flag
+  changes that silently widen permissions to work around this instead of handling it deliberately.
 - `.env`, `web/app/uploads/`, and `web/.htaccess` must stay excluded from rsync. Flag removal of
   these exclusions.
 - Flag secrets referenced outside GitHub Secrets, or secrets echoed into logs.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,6 +69,20 @@ jobs:
           name: build
           path: build
 
+      - name: Unlock files for sync
+        uses: appleboy/ssh-action@v1.2.5
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_KEY }}
+          port: ${{ secrets.DEPLOY_PORT }}
+          script: |
+            cd ${{ secrets.DEPLOY_PATH }}
+            # The previous deploy locked directories to 555; re-add owner write
+            # so rsync can create, replace and delete entries. uploads/ is
+            # already writable and stays untouched.
+            find . -path ./web/app/uploads -prune -o -type d -exec chmod u+w {} +
+
       - name: Deploy via rsync
         uses: burnett01/rsync-deployments@8.0.5
         with:
@@ -80,7 +94,7 @@ jobs:
           remote_key: ${{ secrets.DEPLOY_KEY }}
           remote_port: ${{ secrets.DEPLOY_PORT }}
 
-      - name: Clear cache on server
+      - name: Lock down file permissions
         uses: appleboy/ssh-action@v1.2.5
         with:
           host: ${{ secrets.DEPLOY_HOST }}
@@ -89,9 +103,17 @@ jobs:
           port: ${{ secrets.DEPLOY_PORT }}
           script: |
             cd ${{ secrets.DEPLOY_PATH }}
-            if [ -f ".env" ]; then
-              chmod 600 .env
-            fi
             if [ -d "web/app/cache" ]; then
               rm -rf web/app/cache/*
+            fi
+            # Make the deployed code tree read-only. Nothing but uploads/ needs
+            # runtime writes (DISALLOW_FILE_EDIT/MODS are set), so this blocks
+            # the common case of a compromised plugin dropping a webshell.
+            # uploads/ and .env are pruned so they keep their own permissions.
+            # When adding file-based object/page caching, whitelist the cache
+            # dir here the same way uploads/ is handled — see issue #33.
+            find . -path ./web/app/uploads -prune -o -name .env -prune -o -type d -exec chmod 555 {} +
+            find . -path ./web/app/uploads -prune -o -name .env -prune -o -type f -exec chmod 444 {} +
+            if [ -f ".env" ]; then
+              chmod 600 .env
             fi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,6 +77,7 @@ jobs:
           key: ${{ secrets.DEPLOY_KEY }}
           port: ${{ secrets.DEPLOY_PORT }}
           script: |
+            set -eu
             cd ${{ secrets.DEPLOY_PATH }}
             # The previous deploy locked directories to 555; re-add owner write
             # so rsync can create, replace and delete entries. uploads/ is
@@ -102,6 +103,7 @@ jobs:
           key: ${{ secrets.DEPLOY_KEY }}
           port: ${{ secrets.DEPLOY_PORT }}
           script: |
+            set -eu
             cd ${{ secrets.DEPLOY_PATH }}
             if [ -d "web/app/cache" ]; then
               rm -rf web/app/cache/*
@@ -110,6 +112,9 @@ jobs:
             # runtime writes (DISALLOW_FILE_EDIT/MODS are set), so this blocks
             # the common case of a compromised plugin dropping a webshell.
             # uploads/ and .env are pruned so they keep their own permissions.
+            # web/.htaccess is rsync-excluded but still locked to 444 here on
+            # purpose (it falls under the find); runtime permalink rewrites need
+            # a manual unlock — see the trade-off in .gemini/styleguide.md.
             # When adding file-based object/page caching, whitelist the cache
             # dir here the same way uploads/ is handled — see issue #33.
             find . -path ./web/app/uploads -prune -o -name .env -prune -o -type d -exec chmod 555 {} +


### PR DESCRIPTION
Hardens the production deploy beyond the `755`/`644` normalization from #31 (which is just the
WordPress default). Makes the deployed code tree **read-only**, whitelisting only the one
directory that needs runtime writes.

## What changes (`.github/workflows/deploy.yml`)

- **New "Unlock files for sync" step** (pre-rsync): `chmod u+w` on all code-tree directories
  (excluding `web/app/uploads/`) so rsync can write into a tree the previous deploy locked.
- **"Clear cache on server" → "Lock down file permissions"** (post-rsync): after clearing the
  (currently unused) cache dir, set the code tree to `555` dirs / `444` files. `web/app/uploads/`
  and `.env` are pruned from the `find`, so uploads keeps its writable perms and `.env` keeps
  `600`.

## Why this is the real hardening

Code arrives via rsync and `DISALLOW_FILE_EDIT` + `DISALLOW_FILE_MODS` are set, so PHP never
legitimately writes the code tree. Audit confirmed only `web/app/uploads/` needs runtime write
(no caching drop-ins, `languages/` and `upgrade/` are read-only-safe). Read-only perms stop the
common case of a compromised plugin/theme dropping a webshell.

**Honest caveat:** PHP runs as the same account user that owns the files (cPanel), so an
attacker with PHP execution could `chmod` back. This is a strong speed bump against
naïve/automated attacks, not an absolute wall — true immutability needs web-uid ≠ file-owner,
which shared cPanel doesn't offer.

## Follow-ups

- Object/page caching is planned but not active. When added, a file-based backend would need the
  cache dir whitelisted in the lockdown — captured in #33 (a daemon-based Redis/Memcached cache
  needs no change). A pointer comment to #33 is left in the workflow.

## Known trade-off

With `web/` at `555`, WP can't rewrite `web/.htaccess` on a permalink change (rare; handled by a
manual unlock).

## Verification

Workflow only runs on a `v*` tag / manual dispatch, so this merge can't exercise it. On the next
release, after the lock step:

```
find web -path web/app/uploads -prune -o -type d ! -perm 555 -print   # expect empty
find web -path web/app/uploads -prune -o -type f ! -perm 444 -print   # expect empty
stat -c '%a' web/app/uploads                                          # expect 755
stat -c '%a' .env                                                     # expect 600
# upload a media file in wp-admin → succeeds
```

Closes #32
