### PR TITLE
feat(security): add security headers mu-plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 !/web/app/mu-plugins/.gitkeep
 !/web/app/mu-plugins/msls-deepl-translate.php
 !/web/app/mu-plugins/change-password-wellknown.php
+!/web/app/mu-plugins/security-headers.php
 
 # Uploads
 /web/app/uploads/*

--- a/web/app/mu-plugins/security-headers.php
+++ b/web/app/mu-plugins/security-headers.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Plugin Name: Security Headers
+ * Description: Sends hardened HTTP security response headers on front-end, admin and login responses.
+ */
+
+namespace Chrdm\SecurityHeaders;
+
+add_action( 'send_headers', __NAMESPACE__ . '\\send', 99 );
+add_action( 'login_init', __NAMESPACE__ . '\\send', 99 );
+add_action( 'admin_init', __NAMESPACE__ . '\\send', 99 );
+
+/**
+ * Emits the security headers, adapting a few values to the request context.
+ *
+ * Values follow https://specification.website/spec/security/. HSTS is sent
+ * only over TLS, and frame denial is skipped on WordPress's own post-embed
+ * responses so the oEmbed feature keeps working when other sites embed us.
+ */
+function send(): void {
+	if ( \headers_sent() ) {
+		return;
+	}
+
+	\header( 'X-Content-Type-Options: nosniff' );
+	\header( 'Referrer-Policy: strict-origin-when-cross-origin' );
+	\header( 'Cross-Origin-Opener-Policy: same-origin' );
+	\header( 'Cross-Origin-Resource-Policy: same-site' );
+	\header(
+		'Permissions-Policy: accelerometer=(), camera=(), geolocation=(), gyroscope=(), '
+		. 'magnetometer=(), microphone=(), payment=(), usb=(), interest-cohort=()',
+	);
+
+	// HSTS commits clients to HTTPS; only ever send it over a secure connection.
+	// `preload` is intentionally omitted until every *.christoph-daum.de subdomain
+	// is confirmed HTTPS-only — submitting to the preload list is hard to reverse.
+	if ( is_ssl() ) {
+		\header( 'Strict-Transport-Security: max-age=63072000; includeSubDomains' );
+	}
+
+	// Block framing everywhere except WordPress post embeds, which are meant to
+	// be iframed cross-origin by other sites.
+	if ( ! ( \function_exists( 'is_embed' ) && is_embed() ) ) {
+		\header( 'X-Frame-Options: DENY' );
+	}
+}

--- a/web/app/mu-plugins/security-headers.php
+++ b/web/app/mu-plugins/security-headers.php
@@ -4,7 +4,7 @@
  * Description: Sends hardened HTTP security response headers on front-end, admin and login responses.
  */
 
-namespace Chrdm\SecurityHeaders;
+namespace Apermo\SecurityHeaders;
 
 add_action( 'send_headers', __NAMESPACE__ . '\\send', 99 );
 add_action( 'login_init', __NAMESPACE__ . '\\send', 99 );


### PR DESCRIPTION
Implements #35. Adds `web/app/mu-plugins/security-headers.php` (whitelisted in `.gitignore`)
sending the security headers from https://specification.website/spec/security/ on front-end,
admin and login responses via `send_headers` / `admin_init` / `login_init`.

## Headers sent
- `Strict-Transport-Security: max-age=63072000; includeSubDomains` — **TLS only** (`is_ssl()`).
  `preload` intentionally omitted until every `*.christoph-daum.de` subdomain is confirmed
  HTTPS-only (preload-list submission is hard to reverse).
- `X-Content-Type-Options: nosniff`
- `Referrer-Policy: strict-origin-when-cross-origin`
- `Permissions-Policy:` accelerometer/camera/geolocation/gyroscope/magnetometer/microphone/payment/usb/interest-cohort all `()`
- `Cross-Origin-Opener-Policy: same-origin`
- `Cross-Origin-Resource-Policy: same-site`
- `X-Frame-Options: DENY` — **skipped on WP post embeds** (`is_embed()`) so oEmbed still works.

## Notes
- Delivered as a mu-plugin rather than `web/.htaccess` because `.htaccess` is excluded from
  rsync (unversioned on the server); this keeps the config in git and deploys normally.
- CSP / `frame-ancestors` is deliberately out of scope (tracked separately) — it needs a
  report-only rollout on WordPress.
- `php -l` clean; phpcs clean apart from the unavoidable `Plugin Name:` header warning (same as
  the existing mu-plugin). CI runs `php -l`, not phpcs.

## Verify on next deploy
`curl -I https://christoph-daum.de/` shows the headers; confirm a WP post embed
(`/<post>/embed/`) is still frameable and cross-subdomain assets still load.
