### PR TITLE
feat(security): publish /.well-known/security.txt

### DIFF
--- a/web/.well-known/security.txt
+++ b/web/.well-known/security.txt
@@ -1,0 +1,7 @@
+# Security contact for christoph-daum.de / .com — RFC 9116
+# https://specification.website/spec/security/security-txt/
+
+Contact: mailto:christoph.daum@coding-pioneers.com
+Expires: 2027-06-01T00:00:00Z
+Preferred-Languages: de, en
+Canonical: https://christoph-daum.de/.well-known/security.txt

--- a/web/.well-known/security.txt
+++ b/web/.well-known/security.txt
@@ -1,7 +1,7 @@
 # Security contact for christoph-daum.de / .com — RFC 9116
 # https://specification.website/spec/security/security-txt/
 
-Contact: mailto:christoph.daum@coding-pioneers.com
+Contact: mailto:me@christoph-daum.de
 Expires: 2027-06-01T00:00:00Z
 Preferred-Languages: de, en
 Canonical: https://christoph-daum.de/.well-known/security.txt


### PR DESCRIPTION
Implements #36. Adds a static `web/.well-known/security.txt` (RFC 9116). It sits beside
`web/wp/`, so the front-controller `.htaccess` serves it as a real file (`-f` RewriteCond) on
both the `.de` and `.com` hosts, as `text/plain`.

## Fields
- `Contact: mailto:christoph.daum@coding-pioneers.com` — ⚠️ **please confirm / swap if you'd
  prefer a `security@christoph-daum.de` alias.** Used a known-monitored address rather than a
  placeholder so the file is actually actionable.
- `Expires: 2027-06-01T00:00:00Z` — ~1 year out; needs refreshing before it lapses.
- `Preferred-Languages: de, en`
- `Canonical: https://christoph-daum.de/.well-known/security.txt`

## Verify on next deploy
`curl https://christoph-daum.de/.well-known/security.txt` returns the file as `text/plain`
(and the same on the `.com`).
