### PR TITLE
feat(security): redirect /.well-known/change-password

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 /web/app/mu-plugins/*
 !/web/app/mu-plugins/.gitkeep
 !/web/app/mu-plugins/msls-deepl-translate.php
+!/web/app/mu-plugins/change-password-wellknown.php
 
 # Uploads
 /web/app/uploads/*

--- a/web/app/mu-plugins/change-password-wellknown.php
+++ b/web/app/mu-plugins/change-password-wellknown.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Plugin Name: Change Password Well-Known
+ * Description: Redirects /.well-known/change-password to the WordPress profile screen.
+ */
+
+namespace Chrdm\ChangePassword;
+
+add_action( 'init', __NAMESPACE__ . '\\maybe_redirect' );
+
+/**
+ * Redirects the well-known change-password URL to the profile screen.
+ *
+ * Password managers probe /.well-known/change-password; a 302 to the WordPress
+ * profile lets them deep-link the user straight to the password form.
+ * Unauthenticated visitors are bounced through wp-login and back by wp-admin
+ * itself, so no extra handling is needed here.
+ */
+function maybe_redirect(): void {
+	if ( ! isset( $_SERVER['REQUEST_URI'] ) ) {
+		return;
+	}
+
+	$path = untrailingslashit(
+		(string) wp_parse_url( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ), \PHP_URL_PATH ),
+	);
+
+	if ( $path !== '/.well-known/change-password' ) {
+		return;
+	}
+
+	wp_safe_redirect( admin_url( 'profile.php' ), 302 );
+	exit();
+}

--- a/web/app/mu-plugins/change-password-wellknown.php
+++ b/web/app/mu-plugins/change-password-wellknown.php
@@ -4,7 +4,7 @@
  * Description: Redirects /.well-known/change-password to the WordPress profile screen.
  */
 
-namespace Chrdm\ChangePassword;
+namespace Apermo\ChangePassword;
 
 add_action( 'init', __NAMESPACE__ . '\\maybe_redirect' );
 


### PR DESCRIPTION
Implements #37. Adds `web/app/mu-plugins/change-password-wellknown.php` (whitelisted in
`.gitignore`) that 302-redirects `/.well-known/change-password` → `admin_url('profile.php')`.

## Behaviour
- Matches the path on `init` (trailing slash tolerant) and issues `wp_safe_redirect(…, 302)`.
- `admin_url()` resolves per-subsite on multisite, so each host points at its own profile.
- Unauthenticated visitors are bounced through `wp-login.php` and back by wp-admin itself —
  satisfies the spec requirement that the endpoint work when logged out.
- Never returns 404 (which would signal "feature unsupported" to password managers).

## Notes
- Chosen over a Redirection-plugin DB rule so the behaviour is version-controlled and deploys
  with the repo.
- `php -l` clean; phpcs clean (apart from the standard `Plugin Name:` header warning).

## Verify on next deploy
`curl -I https://christoph-daum.de/.well-known/change-password` → `302` with
`Location: …/wp-admin/profile.php`.
