### PR TITLE
feat(seo): declare AI-usage preferences in robots.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@
 !/web/app/mu-plugins/msls-deepl-translate.php
 !/web/app/mu-plugins/change-password-wellknown.php
 !/web/app/mu-plugins/security-headers.php
+!/web/app/mu-plugins/robots-content-signal.php
 
 # Uploads
 /web/app/uploads/*

--- a/web/app/mu-plugins/robots-content-signal.php
+++ b/web/app/mu-plugins/robots-content-signal.php
@@ -4,7 +4,7 @@
  * Description: Adds Content-Signal AI-usage preferences and AI-crawler rules to robots.txt.
  */
 
-namespace Chrdm\RobotsContentSignal;
+namespace Apermo\RobotsContentSignal;
 
 add_filter( 'robots_txt', __NAMESPACE__ . '\\filter', 99, 2 );
 

--- a/web/app/mu-plugins/robots-content-signal.php
+++ b/web/app/mu-plugins/robots-content-signal.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Plugin Name: Robots Content Signal
+ * Description: Adds Content-Signal AI-usage preferences and AI-crawler rules to robots.txt.
+ */
+
+namespace Chrdm\RobotsContentSignal;
+
+add_filter( 'robots_txt', __NAMESPACE__ . '\\filter', 99, 2 );
+
+/**
+ * Appends AI-usage preferences to the generated robots.txt.
+ *
+ * Declares Content-Signal (search=yes, ai-input=yes, ai-train=no) in the
+ * default group and opts known training crawlers out entirely, while search
+ * engines and user-initiated retrieval bots stay allowed via the * group.
+ *
+ * @param string $output The generated robots.txt body.
+ * @param bool   $public Whether the site asks to be indexed.
+ * @return string The robots.txt body with AI-usage rules appended.
+ */
+function filter( string $output, bool $public ): string {
+	if ( ! $public ) {
+		return $output;
+	}
+
+	$signal = 'Content-Signal: search=yes, ai-input=yes, ai-train=no';
+
+	if ( ! \str_contains( $output, 'Content-Signal:' ) ) {
+		if ( \str_contains( $output, 'User-agent: *' ) ) {
+			$output = \preg_replace( '/^User-agent: \*\R/m', '${0}' . $signal . "\n", $output, 1 );
+		} else {
+			$output = "User-agent: *\n{$signal}\n\n" . $output;
+		}
+	}
+
+	// Crawlers used to build training corpora — opted out for ai-train=no.
+	// Search bots (e.g. Applebot, Googlebot) and user-initiated retrieval bots
+	// (OAI-SearchBot, ChatGPT-User, PerplexityBot) remain allowed by the * group.
+	$blocked = [
+		'GPTBot',
+		'ClaudeBot',
+		'anthropic-ai',
+		'CCBot',
+		'Google-Extended',
+		'Applebot-Extended',
+		'Bytespider',
+		'Meta-ExternalAgent',
+	];
+
+	$rules = "\n# ai-train=no — opt training crawlers out (see Content-Signal above).\n";
+	foreach ( $blocked as $agent ) {
+		$rules .= "User-agent: {$agent}\nDisallow: /\n\n";
+	}
+
+	return \rtrim( $output ) . "\n" . \rtrim( $rules ) . "\n";
+}


### PR DESCRIPTION
Implements #38. Adds `web/app/mu-plugins/robots-content-signal.php` (whitelisted in `.gitignore`)
hooking the `robots_txt` filter (priority 99, after Yoast).

## Policy: `search=yes, ai-input=yes, ai-train=no`
- Injects `Content-Signal: search=yes, ai-input=yes, ai-train=no` **into the existing
  `User-agent: *` group** (per the spec's placement), falling back to a new group if absent.
- Disallows known **training** crawlers: `GPTBot`, `ClaudeBot`, `anthropic-ai`, `CCBot`,
  `Google-Extended`, `Applebot-Extended`, `Bytespider`, `Meta-ExternalAgent`.
- Leaves **search** engines (Googlebot, Applebot) and **user-initiated retrieval** bots
  (OAI-SearchBot, ChatGPT-User, PerplexityBot) allowed via the `*` group — matching `ai-input=yes`.

## Sample output (verified locally)
```
User-agent: *
Content-Signal: search=yes, ai-input=yes, ai-train=no
Disallow: /wp-admin/
Allow: /wp-admin/admin-ajax.php

Sitemap: …

# ai-train=no — opt training crawlers out (see Content-Signal above).
User-agent: GPTBot
Disallow: /
…
```

## Notes
- WordPress serves a **virtual** robots.txt per subsite; the filter applies on both `.de`/`.com`
  and all subdomains. Skips output when the site isn't public (`$public` false).
- `Content-Signal` is an emerging IETF aipref / IAB Tech Lab proposal — ignored by parsers that
  don't support it yet, so it's safe to ship.
- `php -l` + phpcs clean (bar the `Plugin Name:` header warning).

## Verify on next deploy
`curl https://christoph-daum.de/robots.txt` shows the Content-Signal line and crawler groups.
