### PR TITLE
feat(i18n): add x-default to MSLS hreflang output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@
 !/web/app/mu-plugins/change-password-wellknown.php
 !/web/app/mu-plugins/security-headers.php
 !/web/app/mu-plugins/robots-content-signal.php
+!/web/app/mu-plugins/hreflang-x-default.php
 
 # Uploads
 /web/app/uploads/*

--- a/web/app/mu-plugins/hreflang-x-default.php
+++ b/web/app/mu-plugins/hreflang-x-default.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Plugin Name: hreflang x-default
+ * Description: Adds an x-default alternate to MSLS hreflang output when several translations exist.
+ */
+
+namespace Chrdm\HreflangXDefault;
+
+add_filter( 'msls_output_get_alternate_links_arr', __NAMESPACE__ . '\\add_x_default' );
+
+/**
+ * Adds an x-default hreflang alternate to the MSLS head links.
+ *
+ * MSLS only emits x-default when a single alternate exists; with several
+ * translations it omits it. This points x-default at the first listed
+ * alternate — matching MSLS's own single-alternate behaviour — so search
+ * engines have a fallback when no language matches the visitor.
+ *
+ * @param array $links Alternate <link> tags produced by MSLS.
+ * @return array The links with an x-default entry prepended.
+ */
+function add_x_default( array $links ): array {
+	if ( \count( $links ) < 2 ) {
+		return $links;
+	}
+
+	foreach ( $links as $link ) {
+		if ( \str_contains( $link, 'hreflang="x-default"' ) ) {
+			return $links;
+		}
+	}
+
+	$x_default = \preg_replace( '/hreflang="[^"]*"/', 'hreflang="x-default"', $links[0], 1 );
+
+	if ( \is_string( $x_default ) && $x_default !== '' ) {
+		\array_unshift( $links, $x_default );
+	}
+
+	return $links;
+}

--- a/web/app/mu-plugins/hreflang-x-default.php
+++ b/web/app/mu-plugins/hreflang-x-default.php
@@ -4,7 +4,7 @@
  * Description: Adds an x-default alternate to MSLS hreflang output when several translations exist.
  */
 
-namespace Chrdm\HreflangXDefault;
+namespace Apermo\HreflangXDefault;
 
 add_filter( 'msls_output_get_alternate_links_arr', __NAMESPACE__ . '\\add_x_default' );
 


### PR DESCRIPTION
Implements #39. Adds `web/app/mu-plugins/hreflang-x-default.php` (whitelisted in `.gitignore`).

## What I found in MSLS (`includes/MslsOutput.php::get_alternate_links`)
- **Self-reference** ✓ — the current blog is part of the iterated collection, so its own
  `hreflang` link is emitted.
- **Reciprocity** ✓ — inherent to MSLS's linked-translations model.
- **x-default** ✗ — built into `$default`, but only *returned* when there's exactly **one**
  alternate (`count($arr) === 1`). With multiple translations it returns `implode($arr)` and
  drops x-default — i.e. it's missing precisely when it matters.

## Fix
Hook `msls_output_get_alternate_links_arr` and prepend an `x-default` entry (idempotent; skipped
when <2 links or one is already present). It points x-default at the **first listed alternate**,
matching MSLS's own choice in the single-alternate branch.

Verified locally:
```
<link rel="alternate" href="https://christoph-daum.de/post/" hreflang="x-default" />
<link rel="alternate" href="https://christoph-daum.de/post/" hreflang="de" />
<link rel="alternate" href="https://christoph-daum.com/post/" hreflang="en" />
```

## Notes / verification
- This is the apermo MSLS fork (`lloc/multisite-language-switcher: dev-master`).
- BCP 47 tags come from MSLS's per-blog language config — **confirm on the live site** they're
  valid (`de` / `en`, or region-qualified), and that Yoast's canonical doesn't conflict.
- After deploy, view-source on a translated post should show reciprocal alternates **plus**
  `x-default`; validate in GSC "International targeting" / a hreflang checker.
- `php -l` + phpcs clean (bar the `Plugin Name:` header warning).
