### PR TITLE
docs: document consent-free-by-design privacy stance

### DIFF
--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -17,6 +17,8 @@ parties, no cookie banner. This is enforced by the stack (`statify`, `embed-priv
 - Flag any change that introduces plugins, blocks, embeds, web fonts, or scripts that set
   non-essential cookies or require consent (e.g. Google Fonts loaded from Google, Google
   Analytics, Meta Pixel, unblocked third-party embeds).
+- Flag changes that would sell or share personal data, or ignore Global Privacy Control
+  (`Sec-GPC`), which the site honours by design.
 - Prefer self-hosted, cookieless alternatives. Treat regressions here as high severity.
 
 ## Configuration & Bedrock

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,8 +11,9 @@ WordPress multisite installation for christoph-daum.de using [Bedrock](https://r
 The site is **consent-free by design**: it sets no non-essential cookies and loads no
 consent-requiring third parties, so it runs **without a cookie-consent banner**. This is enforced
 by the stack — `statify` (cookieless analytics), `embed-privacy` (third-party embeds blocked until
-opt-in), `antispam-bee` (no external service), and no ad/retargeting tags. Global Privacy Control
-is satisfied because no personal data is sold or shared.
+opt-in) and `antispam-bee` (no external service) — plus a strict no-tracking policy (no ad,
+retargeting or data-broker tags). Global Privacy Control is satisfied because no personal data is
+sold or shared.
 
 **Do not break this.** Do not introduce plugins, blocks, embeds, web fonts, or scripts that set
 non-essential cookies or require consent (e.g. Google Fonts loaded from Google, Google

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,19 @@ This file provides guidance for Claude Code when working with this repository.
 
 WordPress multisite installation for christoph-daum.de using [Bedrock](https://roots.io/bedrock/) architecture. The project uses Composer for dependency management and GitHub Actions for automated deployments to cPanel shared hosting.
 
+## Privacy — consent-free by design (hard constraint)
+
+The site is **consent-free by design**: it sets no non-essential cookies and loads no
+consent-requiring third parties, so it runs **without a cookie-consent banner**. This is enforced
+by the stack — `statify` (cookieless analytics), `embed-privacy` (third-party embeds blocked until
+opt-in), `antispam-bee` (no external service), and no ad/retargeting tags. Global Privacy Control
+is satisfied because no personal data is sold or shared.
+
+**Do not break this.** Do not introduce plugins, blocks, embeds, web fonts, or scripts that set
+non-essential cookies or require consent (e.g. Google Fonts loaded from Google, Google
+Analytics, Meta Pixel, unblocked third-party embeds) without explicitly revisiting this decision
+with the user first. Prefer self-hosted, cookieless alternatives.
+
 ## Architecture
 
 ### Directory Structure

--- a/README.md
+++ b/README.md
@@ -65,6 +65,22 @@ Push to `main` branch triggers automatic deployment via GitHub Actions.
 2. Configure wildcard DNS for subdomains: `*.christoph-daum.de`
 3. Create database and update `.env`
 
+## Privacy — consent-free by design
+
+This site sets **no non-essential cookies and loads no consent-requiring third parties**, so it
+needs **no cookie-consent banner**. The stance is enforced by the plugin stack:
+
+- **statify** — cookieless, aggregated analytics (no personal data, no tracking cookies).
+- **embed-privacy** — blocks third-party embeds (YouTube, etc.) until the visitor opts in
+  per-embed, so no third-party cookies load on page view.
+- **antispam-bee** — privacy-friendly spam filtering with no external service.
+- No advertising, retargeting, or data-broker tags.
+
+Because nothing sells or shares personal data, Global Privacy Control (`Sec-GPC`) is honoured by
+design. **Keep the site consent-free:** do not add plugins, embeds, fonts, or scripts that set
+non-essential cookies or require consent without revisiting this decision (see
+[CLAUDE.md](CLAUDE.md)).
+
 ## Documentation
 
 See [CLAUDE.md](CLAUDE.md) for detailed development guidelines.

--- a/README.md
+++ b/README.md
@@ -68,13 +68,14 @@ Push to `main` branch triggers automatic deployment via GitHub Actions.
 ## Privacy — consent-free by design
 
 This site sets **no non-essential cookies and loads no consent-requiring third parties**, so it
-needs **no cookie-consent banner**. The stance is enforced by the plugin stack:
+needs **no cookie-consent banner**. The stance is enforced by the plugin stack and a strict
+no-tracking policy:
 
 - **statify** — cookieless, aggregated analytics (no personal data, no tracking cookies).
 - **embed-privacy** — blocks third-party embeds (YouTube, etc.) until the visitor opts in
   per-embed, so no third-party cookies load on page view.
 - **antispam-bee** — privacy-friendly spam filtering with no external service.
-- No advertising, retargeting, or data-broker tags.
+- **No tracking tags** — no advertising, retargeting, or data-broker tags load anywhere.
 
 Because nothing sells or shares personal data, Global Privacy Control (`Sec-GPC`) is honoured by
 design. **Keep the site consent-free:** do not add plugins, embeds, fonts, or scripts that set


### PR DESCRIPTION
Implements #40. Documents the consent-free-by-design privacy stance.

- **README.md** — new "Privacy — consent-free by design" section explaining the no-banner design
  and the plugins that enforce it (statify, embed-privacy, antispam-bee), and that GPC is honoured
  by design.
- **CLAUDE.md** — a hard-constraint note near the top so future work doesn't silently reintroduce
  a consent requirement (e.g. Google-hosted fonts, GA, Meta Pixel, unblocked embeds) without
  revisiting the decision.

No code changes. Lines wrapped at 120 per repo markdown convention.
