### PR TITLE
chore: add Gemini Code Assist config

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,24 @@
+have_fun: true
+
+ignore_patterns:
+  - "vendor/**"
+  - "node_modules/**"
+  - "web/wp/**"
+  - "web/app/plugins/**"
+  - "web/app/themes/**"
+  - "web/app/uploads/**"
+  - "web/app/languages/**"
+  - "*.min.js"
+  - "*.min.css"
+  - "package-lock.json"
+  - "composer.lock"
+
+code_review:
+  disable: false
+  comment_severity_threshold: MEDIUM
+  max_review_comments: -1
+  pull_request_opened:
+    help: false
+    summary: true
+    code_review: true
+    include_drafts: true

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -30,11 +30,13 @@ parties, no cookie banner. This is enforced by the stack (`statify`, `embed-priv
 
 ## Deployment & CI (`.github/workflows/`)
 
-- The deploy is tag-triggered (`v*`) or manual dispatch; merges to `main` do **not** deploy.
-  Flag changes that would auto-deploy on push.
-- The deployed code tree is locked read-only (`555`/`444`), with only `web/app/uploads/`
-  writable. Flag changes that broaden writable paths without justification, or that would let
-  rsync `--delete` wipe runtime state (uploads, caches).
+- The deploy is tag-triggered (tags matching `v[0-9]+.[0-9]+.[0-9]+`) or manual dispatch; merges
+  to `main` do **not** deploy. Flag changes that would auto-deploy on push, or that loosen the
+  tag pattern to fire on non-release tags.
+- The deploy syncs with `--chmod=D755,F644` and tightens `.env` to `600`. Flag changes that
+  broaden writable paths without justification, or that would let rsync `--delete` wipe runtime
+  state (uploads, caches). (A stricter read-only lockdown of the code tree — `555`/`444` with
+  only `web/app/uploads/` writable — is proposed in PR #34; update this section when it lands.)
 - `.env`, `web/app/uploads/`, and `web/.htaccess` must stay excluded from rsync. Flag removal of
   these exclusions.
 - Flag secrets referenced outside GitHub Secrets, or secrets echoed into logs.
@@ -75,6 +77,6 @@ parties, no cookie banner. This is enforced by the stack (`statify`, `embed-priv
 
 ## Commits
 
-- This project uses [Conventional Commits](https://www.conventionalcommits.org/) with a 50-char
-  subject / 72-char body limit, enforced by git hooks and CI.
+- This project follows [Conventional Commits](https://www.conventionalcommits.org/) with a
+  50-char subject / 72-char body limit (convention, not currently CI-enforced).
 - Each commit should address a single concern and be atomic (cherry-pickable, revertable).

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -1,0 +1,80 @@
+# chrdm.de - Code Review Style Guide
+
+## Project Context
+
+This is the WordPress multisite installation for christoph-daum.de, built on the
+[Bedrock](https://roots.io/bedrock/) architecture. It is an **infrastructure / deployment repo**,
+not a plugin or theme: the theme (`sovereignty`) and plugins are pulled in via Composer and
+symlinked locally, so the code reviewed here is mostly configuration, the deploy workflow, and
+glue. Deployment targets cPanel shared hosting via GitHub Actions on `v*` tags.
+
+## Privacy — consent-free by design (hard constraint)
+
+The site is **consent-free by design**: no non-essential cookies, no consent-requiring third
+parties, no cookie banner. This is enforced by the stack (`statify`, `embed-privacy`,
+`antispam-bee`, no ad/retargeting tags).
+
+- Flag any change that introduces plugins, blocks, embeds, web fonts, or scripts that set
+  non-essential cookies or require consent (e.g. Google Fonts loaded from Google, Google
+  Analytics, Meta Pixel, unblocked third-party embeds).
+- Prefer self-hosted, cookieless alternatives. Treat regressions here as high severity.
+
+## Configuration & Bedrock
+
+- Application config lives in `config/application.php` and `config/environments/`; secrets come
+  from `.env` (never committed — only `.env.example` is tracked).
+- Flag any hard-coded secret, credential, salt, or environment-specific value that belongs in
+  `.env`.
+- `DISALLOW_FILE_EDIT` / `DISALLOW_FILE_MODS` are intentional — flag changes that re-enable
+  in-dashboard file editing or runtime file modification.
+
+## Deployment & CI (`.github/workflows/`)
+
+- The deploy is tag-triggered (`v*`) or manual dispatch; merges to `main` do **not** deploy.
+  Flag changes that would auto-deploy on push.
+- The deployed code tree is locked read-only (`555`/`444`), with only `web/app/uploads/`
+  writable. Flag changes that broaden writable paths without justification, or that would let
+  rsync `--delete` wipe runtime state (uploads, caches).
+- `.env`, `web/app/uploads/`, and `web/.htaccess` must stay excluded from rsync. Flag removal of
+  these exclusions.
+- Flag secrets referenced outside GitHub Secrets, or secrets echoed into logs.
+
+## PHP
+
+- PHP 8.3 required. Use strict typing where possible.
+- Follow the [WordPress Coding Standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/);
+  PHPCS is configured via `phpcs.xml.dist`.
+- All output must be escaped (`esc_html()`, `esc_attr()`, `esc_url()`, `wp_kses_post()`).
+- All user input must be sanitized and validated; nonce verification is required for form
+  submissions.
+- Use post-increment (`$i++`) over pre-increment (`++$i`).
+
+## Code Style
+
+- Flag inline comments that merely restate what the code does instead of explaining intent.
+- Flag commented-out code.
+- Do not flag docblocks — these may be required by coding standards even when self-explanatory.
+- Flag new code that duplicates existing functionality in the repository.
+
+## File Operations
+
+- Flag files that appear to be deleted and re-added as new files instead of being moved/renamed
+  (losing git history).
+
+## Build & Packaging
+
+- Flag newly added files or directories that are missing from build/packaging configs
+  (`.gitignore`, `setup-dev.sh`, deploy workflow rsync includes/excludes, etc.).
+- When a new theme or plugin is added, it should be Composer-managed and reflected in
+  `composer.json`, `setup-dev.sh`, and `.gitignore` — flag partial additions.
+
+## Documentation
+
+- If a change affects setup, deployment, or environment behavior, flag missing updates to
+  `README.md` or `CLAUDE.md`.
+
+## Commits
+
+- This project uses [Conventional Commits](https://www.conventionalcommits.org/) with a 50-char
+  subject / 72-char body limit, enforced by git hooks and CI.
+- Each commit should address a single concern and be atomic (cherry-pickable, revertable).


### PR DESCRIPTION
Adds a `.gemini/` folder so Gemini Code Assist reviews PRs on this repo, consistent with the other apermo repositories (`template-wordpress`, `sovereignty`, `reusable-workflows`, etc.) which all carry the same setup.

## What's added

- **`.gemini/config.yaml`** — same base config as the other repos (summary + code review on PR open, MEDIUM severity threshold, no comment cap), with `ignore_patterns` tailored to this Bedrock layout: Composer-managed `vendor/`, `web/wp/`, `web/app/{plugins,themes,uploads,languages}/`, plus minified assets and lockfiles.
- **`.gemini/styleguide.md`** — review guidance specific to this repo rather than a plugin/theme:
  - The **consent-free privacy constraint** (no consent-requiring cookies/embeds/fonts/tags) as a high-severity flag.
  - **Deployment/CI** rules: tag-triggered deploy only, read-only deployed tree with only `uploads/` writable, rsync exclusions, no secrets in logs.
  - **Bedrock config**: secrets via `.env` only, `DISALLOW_FILE_EDIT`/`MODS` intentional.
  - PHP 8.3 / WPCS, escaping, sanitization; Conventional Commits 50/72.

## Notes

- Doc-only; no runtime or deploy behavior changes.
- Branched off `main` in an isolated worktree so it doesn't interfere with the in-progress work on another branch.