### PR TITLE
refactor: use Apermo namespace for MSLS DeepL plugin

### DIFF
--- a/web/app/mu-plugins/msls-deepl-translate.php
+++ b/web/app/mu-plugins/msls-deepl-translate.php
@@ -4,7 +4,7 @@
  * Description: Translates title and content via DeepL when using MSLS quick-create.
  */
 
-namespace Chrdm\MslsDeepl;
+namespace Apermo\MslsDeepl;
 
 use lloc\Msls\MslsBlogCollection;
 use lloc\Msls\MslsRestApi;


### PR DESCRIPTION
Migrates the existing `msls-deepl-translate.php` mu-plugin from `Chrdm\MslsDeepl` to `Apermo\MslsDeepl`, completing the move to a single `Apermo\` vendor namespace across all mu-plugins (alongside the namespace fixes in #41, #43, #44, #45).

The `Translator` class is only referenced within its own namespace (`self::class` / `Translator::class`), and a repo-wide grep found no external references to `Chrdm\MslsDeepl`, so the change is self-contained.

`php -l` clean.