### PR TITLE
fix(deploy): include hidden files in build artifact

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,6 +50,9 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: build
+          # Hidden files are excluded by default since upload-artifact v4.4;
+          # we need them so web/.well-known/ (security.txt etc.) gets deployed.
+          include-hidden-files: true
           path: |
             .
             !.git


### PR DESCRIPTION
## Problem

`v1.4.0` deployed successfully, but `https://christoph-daum.de/.well-known/security.txt` returns
**404**. The file is committed (`web/.well-known/security.txt`) and present in the tag, but it
never reached the server.

## Root cause

`actions/upload-artifact` **excludes hidden files and directories by default** since v4.4. The
deploy uses `@v7` without `include-hidden-files`, so `web/.well-known/` (a dot-directory) was
silently dropped from the build artifact and never rsync'd.

This is why `/.well-known/change-password` works (PHP-routed through `index.php`, needs no file)
but the static `security.txt` 404s.

## Fix

Add `include-hidden-files: true` to the upload step so dot-directories ship.

## After merge

Needs a patch release (**v1.4.1**) to redeploy and bring `security.txt` live. The other v1.4.0
features are already verified in production (security headers, change-password redirect,
robots.txt Content-Signal).