### PR TITLE
docs: credit specification.website, fix deploy + standards docs

### DIFF
--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -52,12 +52,26 @@ parties, no cookie banner. This is enforced by the stack (`statify`, `embed-priv
 ## PHP
 
 - PHP 8.3 required. Use strict typing where possible.
-- Follow the [WordPress Coding Standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/);
-  PHPCS is configured via `phpcs.xml.dist`.
+- Code style is the **`Apermo` PHPCS ruleset** (`phpcs.xml.dist`, scanning `config/` and
+  `web/app/mu-plugins/`) — WPCS-derived but with deliberate deviations. Do **not** flag these as
+  errors: fully-qualified native calls in namespaced code (`\header()`), **no Yoda conditions**
+  (`$x === 'y'`, not `'y' === $x`), and trailing commas after the last argument in multi-line
+  calls.
 - All output must be escaped (`esc_html()`, `esc_attr()`, `esc_url()`, `wp_kses_post()`).
 - All user input must be sanitized and validated; nonce verification is required for form
   submissions.
 - Use post-increment (`$i++`) over pre-increment (`++$i`).
+
+## Must-use plugins (`web/app/mu-plugins/`)
+
+- Site-specific glue lives as **single-file** mu-plugins, each whitelisted individually in
+  `.gitignore` (the directory is ignore-all + per-file allow). Flag a new mu-plugin that is not
+  whitelisted (it would be silently untracked).
+- Namespace must be **`Apermo\<Feature>`** — flag `Chrdm\…` or other vendor namespaces for
+  consistency.
+- Several implement [specification.website](https://specification.website) adoptions (security
+  headers, `robots.txt` Content-Signal, hreflang `x-default`). The consent-free constraint above
+  still applies.
 
 ## Code Style
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,23 @@ Install via Composer from wpackagist:
 composer require wpackagist-plugin/plugin-name
 ```
 
+### Must-Use Plugins (mu-plugins)
+
+Small site-specific glue lives as **single-file** must-use plugins in `web/app/mu-plugins/`.
+Conventions:
+
+- One file per concern, each **whitelisted in `.gitignore`** (the directory is ignore-all +
+  per-file allow).
+- Namespace **`Apermo\<Feature>`** (e.g. `Apermo\SecurityHeaders`). Keep this consistent across
+  all mu-plugins.
+- They follow the **`Apermo` PHPCS ruleset** (see [Coding Standards](#coding-standards)), which
+  differs from vanilla WPCS: fully-qualified native calls in namespaced code (`\header()`),
+  **no Yoda conditions**, trailing commas in multi-line calls, third-person docblock summaries.
+
+Several mu-plugins implement the [Website Specification](https://specification.website)
+adoptions (security headers, `robots.txt` Content-Signal, hreflang `x-default`); the
+`/.well-known/` files are static under `web/.well-known/`.
+
 ## Development Setup
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,8 +105,9 @@ Conventions:
   **no Yoda conditions**, trailing commas in multi-line calls, third-person docblock summaries.
 
 Several mu-plugins implement the [Website Specification](https://specification.website)
-adoptions (security headers, `robots.txt` Content-Signal, hreflang `x-default`); the
-`/.well-known/` files are static under `web/.well-known/`.
+adoptions (security headers, `robots.txt` Content-Signal, hreflang `x-default`, and the
+`/.well-known/change-password` redirect); only `/.well-known/security.txt` is a static file under
+`web/.well-known/`.
 
 ## Development Setup
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,18 @@ cd repos/sovereignty
 
 ## Deployment
 
-Push to `main` branch triggers automatic deployment via GitHub Actions.
+Deploys run via GitHub Actions and are triggered by pushing a **SemVer tag**
+(`vMAJOR.MINOR.PATCH`), or by manual `workflow_dispatch`. Merges to `main` do **not** deploy —
+releases are cut explicitly:
+
+```bash
+git tag v1.2.3 -m "release notes"
+git push origin v1.2.3
+```
+
+The workflow builds (Composer + theme assets), then deploys to the cPanel host via rsync using an
+unlock → sync → read-only-lock sequence: the deployed code tree is left `555`/`444`, with only
+`web/app/uploads/` writable and `.env` tightened to `600`. See [CLAUDE.md](CLAUDE.md) for details.
 
 ### Required GitHub Secrets
 
@@ -82,9 +93,32 @@ design. **Keep the site consent-free:** do not add plugins, embeds, fonts, or sc
 non-essential cookies or require consent without revisiting this decision (see
 [CLAUDE.md](CLAUDE.md)).
 
+## Standards & hardening
+
+The site follows the [Website Specification](https://specification.website) (see
+[Credits](#credits)). The adoptions live as must-use plugins in `web/app/mu-plugins/` (namespaced
+`Apermo\…`):
+
+- **Security headers** — HSTS, `X-Content-Type-Options`, `Referrer-Policy`, `Permissions-Policy`,
+  Cross-Origin-Opener/Resource-Policy, `X-Frame-Options`.
+- **`/.well-known/security.txt`** (RFC 9116) and a **`/.well-known/change-password`** redirect.
+- **`robots.txt` Content-Signal** declaring AI-usage preferences (`ai-train=no`) plus an
+  AI-crawler opt-out.
+- **hreflang `x-default`** for the multilingual `.de` / `.com` setup.
+
+Deploys additionally lock the code tree read-only on the server as defense-in-depth (see
+[Deployment](#deployment)).
+
 ## Documentation
 
 See [CLAUDE.md](CLAUDE.md) for detailed development guidelines.
+
+## Credits
+
+Security, SEO, privacy and i18n hardening follows the
+[**Website Specification**](https://specification.website) by
+[Joost de Valk](https://github.com/jdevalk) — a platform-agnostic, sourced checklist of what a
+good website does ([jdevalk/specification.website](https://github.com/jdevalk/specification.website)).
 
 ## Prerequisites for Theme/Plugins
 


### PR DESCRIPTION
Documentation + review-config pass after the standards-adoption release.

## README
- **Fix factual bug:** Deployment section said "push to `main` triggers deployment" — it's
  **tag-triggered** (`vMAJOR.MINOR.PATCH`) / manual dispatch. Corrected, with the unlock → sync →
  read-only-lock summary.
- **New "Standards & hardening" section** documenting the mu-plugin adoptions (security headers,
  `/.well-known/` files, robots Content-Signal, hreflang x-default) and the read-only deploy lock.
- **New "Credits" section** — shout-out to [specification.website](https://specification.website)
  by Joost de Valk (@jdevalk), which guided the security/SEO/privacy/i18n work. Thanks for the
  excellent, sourced checklist! 🙏

## CLAUDE.md
- Documents the **single-file `Apermo\` mu-plugin convention** (whitelisted in `.gitignore`,
  Apermo PHPCS ruleset).

## Gemini styleguide (coverage fixes)
- The PHP section said "WordPress Coding Standards" but `phpcs.xml.dist` uses the **`Apermo`**
  ruleset, which **disallows Yoda** and **requires fully-qualified natives** — the opposite of
  vanilla WPCS. Corrected so the reviewer doesn't flag correct code.
- Added a **mu-plugins** review section (single-file, whitelisted, `Apermo\` namespace).

Repo description set separately.