### PR TITLE
ci: auto-create GitHub Release on tag deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -125,3 +125,44 @@ jobs:
             if [ -f ".env" ]; then
               chmod 600 .env
             fi
+
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: deploy
+    # Only meaningful for tag deploys; workflow_dispatch on a branch is skipped.
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          # Full history + tags so the annotated tag message is available
+          # to reuse as the release body.
+          fetch-depth: 0
+
+      - name: Create release if it does not exist yet
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME}"
+          # Idempotent: a tag may be pushed that already has a release (e.g.
+          # created together via `gh release create`). Skip quietly so the
+          # deploy is never broken by a duplicate-release error.
+          if gh release view "$tag" >/dev/null 2>&1; then
+            echo "Release $tag already exists — skipping."
+            exit 0
+          fi
+          # Prefer the annotated tag's own message as the release notes;
+          # fall back to auto-generated notes for lightweight tags.
+          notes="$(git for-each-ref "refs/tags/$tag" --format='%(contents)')"
+          if [ -n "${notes//[[:space:]]/}" ]; then
+            printf '%s\n' "$notes" > "$RUNNER_TEMP/notes.md"
+            gh release create "$tag" --title "$tag" --notes-file "$RUNNER_TEMP/notes.md"
+          else
+            gh release create "$tag" --title "$tag" --generate-notes
+          fi
+          echo "Created release $tag."


### PR DESCRIPTION
## Summary

Closes the recurring drift where deploy tags shipped without a matching
GitHub Release (e.g. `v1.4.0`, `v1.4.1` are tags with no release).

Adds a `release` job to the Deploy workflow that runs after a successful
production deploy and:

1. **Creates the release if missing** — for the pushed tag, using the
   annotated tag's own message as the release body (falls back to
   `--generate-notes` for lightweight tags).
2. **Skips quietly if it already exists** — when a tag was created
   alongside its release (e.g. via `gh release create`), the job detects
   the existing release and exits 0, so the deploy never breaks on a
   duplicate-release error.

## Details

- Guarded with `if: startsWith(github.ref, 'refs/tags/v')`, so a
  `workflow_dispatch` run on a branch is skipped.
- Scoped `permissions: contents: write` on the job only.
- `fetch-depth: 0` so the annotated tag message is available.
- Runs `needs: deploy`, so a release is only published once the deploy
  to production has succeeded.

## Not included

The two existing tags `v1.4.0`/`v1.4.1` predate this workflow and won't
be backfilled by it (it only fires on new tag pushes). Those can be
created manually from their existing tag annotations.