### PR TITLE
chore(deps): bump apermo/sovereignty to ^1.5.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "roots/bedrock-disallow-indexing": "^2.0",
     "roots/wordpress": "7.*",
     "roots/wp-config": "^1.0",
-    "apermo/sovereignty": "^1.4.1",
+    "apermo/sovereignty": "^1.5.1",
     "wpackagist-plugin/activitypub": "^8.0",
     "wpackagist-plugin/antispam-bee": "^2.11",
     "wpackagist-plugin/basepress": "^2.17",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "acad2728bfc4211e7c21577d8288a588",
+    "content-hash": "8773a87aa7ddc5fbbd4decd12c0e61cc",
     "packages": [
         {
             "name": "apermo/apermo-notify",
@@ -107,16 +107,16 @@
         },
         {
             "name": "apermo/sovereignty",
-            "version": "1.4.2",
+            "version": "1.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/apermo/sovereignty.git",
-                "reference": "e31317a80282d8ac65d41f3fb62407c654fc16f1"
+                "reference": "60eeb47d76d7c85e775af9ce7dd1b0e89356d620"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/apermo/sovereignty/zipball/e31317a80282d8ac65d41f3fb62407c654fc16f1",
-                "reference": "e31317a80282d8ac65d41f3fb62407c654fc16f1",
+                "url": "https://api.github.com/repos/apermo/sovereignty/zipball/60eeb47d76d7c85e775af9ce7dd1b0e89356d620",
+                "reference": "60eeb47d76d7c85e775af9ce7dd1b0e89356d620",
                 "shasum": ""
             },
             "require": {
@@ -201,7 +201,7 @@
                 "issues": "https://github.com/apermo/sovereignty/issues",
                 "source": "https://github.com/apermo/sovereignty"
             },
-            "time": "2026-05-25T21:05:16+00:00"
+            "time": "2026-06-03T19:46:05+00:00"
         },
         {
             "name": "composer/installers",


### PR DESCRIPTION
Bumps the `apermo/sovereignty` theme to `^1.5.1`.

## Why

Sovereignty 1.5.0 introduced the MSLS language-switcher integration but shipped
a fatal bug: `Integration\Msls::display()` called `msls_get_switcher()` with no
arguments, while the MSLS function signature requires `$attr`
(`function msls_get_switcher( $attr )`, no default). Every front-end page returned
a 500 (`ArgumentCountError`). 1.5.1 fixes the call to pass an argument.

## Verification

Local DDEV install, MSLS active:

- Homepage returns HTTP 200 (was 500 on 1.5.0); no `ArgumentCountError` in the log.
- A language-switcher link renders below the search form (the `sovereignty_after_search`
  hook that the integration registers on).

## Follow-ups (not in this PR)

- MSLS *Display* setting still on flag/code; switch to *Description* for text labels.
- Local-dev theme CSS 404s (unstyled page) — tracked in a separate issue.