### PR TITLE
ci: purge Cachify cache after deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -126,6 +126,24 @@ jobs:
               chmod 600 .env
             fi
 
+      - name: Purge Cachify cache
+        uses: appleboy/ssh-action@v1.2.5
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_KEY }}
+          port: ${{ secrets.DEPLOY_PORT }}
+          script: |
+            set -eu
+            cd ${{ secrets.DEPLOY_PATH }}
+            # rsync updates files but does not invalidate the page cache, so
+            # anonymous visitors keep getting pre-deploy pages until purged.
+            # Flush every site in the network; a single site failing must not
+            # fail the deploy. wp-cli.yml already pins --path to web/wp.
+            for url in $(wp site list --field=url); do
+              wp cachify flush --all-methods --url="$url" || true
+            done
+
   release:
     name: Create GitHub Release
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why

`rsync` updates files on a release but never invalidates the **Cachify** page cache, so
logged-out visitors keep getting pre-deploy pages until a manual purge. Logged-in users
bypass the cache, which is why the staleness is invisible to admins. This is what hid the
new MSLS language switcher from anonymous visitors after the 1.5.1 deploy.

## Change

Adds a *Purge Cachify cache* step to the deploy job, after rsync and the permission lock.
It flushes Cachify for every site in the multisite network over SSH:

```sh
for url in $(wp site list --field=url); do
  wp cachify flush --all-methods --url="$url" || true
done
```

- `wp-cli.yml` already pins `--path` to `web/wp`.
- `--all-methods` clears every configured Cachify method (the current method is not
  file-based, so the existing `rm -rf web/app/cache/*` step does not cover it).
- Per-site failures are tolerated so one bad site cannot fail the deploy.

Closes #58