### PR TITLE
fix: build theme assets in setup-dev.sh

### DIFF
--- a/setup-dev.sh
+++ b/setup-dev.sh
@@ -38,13 +38,18 @@ fi
 # artifact: it is not committed and is generated in CI for production deploys, so
 # a freshly symlinked theme renders unstyled until built locally.
 if [ -f "$REPOS_DIR/sovereignty/package.json" ]; then
-    echo "Building sovereignty theme assets..."
-    (
-        cd "$REPOS_DIR/sovereignty"
-        composer install --no-interaction
-        npm install --no-audit --no-fund
-        npm run build
-    )
+    if command -v composer >/dev/null 2>&1 && command -v npm >/dev/null 2>&1; then
+        echo "Building sovereignty theme assets..."
+        (
+            cd "$REPOS_DIR/sovereignty"
+            composer install --no-interaction
+            npm install --no-audit --no-fund
+            npm run build
+        )
+    else
+        echo "Warning: 'composer' or 'npm' not found. Skipping theme asset build."
+        echo "Install them and build manually: cd repos/sovereignty && npm install && npm run build"
+    fi
 fi
 
 # Add custom plugins here as needed:

--- a/setup-dev.sh
+++ b/setup-dev.sh
@@ -34,6 +34,19 @@ if [ ! -L "$THEMES_DIR/sovereignty" ]; then
     ln -s ../../../repos/sovereignty "$THEMES_DIR/sovereignty"
 fi
 
+# Build theme assets. The compiled CSS (assets/css/*.css, style.css) is a build
+# artifact: it is not committed and is generated in CI for production deploys, so
+# a freshly symlinked theme renders unstyled until built locally.
+if [ -f "$REPOS_DIR/sovereignty/package.json" ]; then
+    echo "Building sovereignty theme assets..."
+    (
+        cd "$REPOS_DIR/sovereignty"
+        composer install --no-interaction
+        npm install --no-audit --no-fund
+        npm run build
+    )
+fi
+
 # Add custom plugins here as needed:
 # Example:
 # if [ ! -d "$REPOS_DIR/my-plugin" ]; then


### PR DESCRIPTION
Closes #56.

## Part (a): local dev site rendered unstyled — fixed here

The theme's compiled CSS (`assets/css/*.css`, `style.css`) is a build
artifact — generated by `npm run build` (grunt/sass), produced in CI for
production deploys, and never committed. `setup-dev.sh` symlinked the theme
but never built it, so every theme stylesheet 404'd and the site was unstyled.

**Change:** after creating the symlink, `setup-dev.sh` now installs the theme's
deps and runs its build (`composer install`, `npm install`, `npm run build`),
guarded on the theme's `package.json` being present.

**Verification** — ran `./setup-dev.sh` from a clean state:
- `web/app/themes/sovereignty/style.css` -> HTTP 200 `text/css` (was 404)
- `.../assets/css/wide-width.css` -> HTTP 200 `text/css`
- Local front end renders styled.

## Part (b): switcher label — already resolved by sovereignty 1.5.2

Verified on production (now running 1.5.2) and locally: the switcher renders
friendly text labels, not flags/locale codes — e.g.
`<span class="current" aria-current="page" lang="de">DE</span><a hreflang="en">EN</a>`.
No admin config needed. Nothing required in this PR.