### PR TITLE
fix(config): force direct filesystem method

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,9 @@ WP_DEBUG_DISPLAY=false
 # Optional
 # DISABLE_WP_CRON=true
 # WP_MEMORY_LIMIT='256M'
+# Filesystem transport; defaults to 'direct'. Override only if the host
+# needs a different method (e.g. 'ftpext').
+# FS_METHOD='direct'
 
 # Production SSH (for bin/pull-db.sh)
 PROD_SSH_USER='your_ssh_user'

--- a/config/application.php
+++ b/config/application.php
@@ -107,6 +107,17 @@ Config::define('COOKIE_DOMAIN', env('COOKIE_DOMAIN') ?: '');
 Config::define('SUNRISE', 'on');
 
 /**
+ * Force direct filesystem access.
+ *
+ * Deployed files are owned by the account user but the content directories
+ * are read-only, so WordPress's filesystem-method probe fails its write test
+ * and falls back to the FTP transport. With no FTP credentials that transport
+ * fatals on a null connection whenever code merely reads a file via
+ * WP_Filesystem (e.g. wpdeepl reading languages.csv during MSLS quick-create).
+ */
+Config::define('FS_METHOD', env('FS_METHOD') ?: 'direct');
+
+/**
  * Debugging settings
  */
 Config::define('WP_DEBUG', env('WP_DEBUG') ?: false);


### PR DESCRIPTION
## Problem

The MSLS "create draft from translation" quick-create feature returns
`500 Internal Server Error` from `POST /wp-json/msls/v1/create-translation`
on production.

## Root cause

The prod PHP `error_log` shows an uncaught `TypeError`:

```
ftp_fget(): Argument #1 ($ftp) must be of type FTP\Connection, null given
  in wp-admin/includes/class-wp-filesystem-ftpext.php:146
```

Call chain:

1. `MslsRestApi::create_translation()` fires the `msls_quick_create_post_data` filter.
2. Our `msls-deepl-translate` mu-plugin calls `deepl_translate()`.
3. wpdeepl's `DeeplConfiguration::DefaultsAllLanguages()` reads `languages.csv`
   via `WP_Filesystem`.
4. WordPress selects the **FTP** transport instead of **direct**, and with no
   FTP credentials the connection is `null` → fatal.

WordPress picks FTP because the deployed content directories are read-only
(`dr-xr-xr-x`), so `get_filesystem_method()`'s direct-method write probe fails
and it falls back to FTP — even though the operation here is only a *read* and
the files are world-readable.

## Fix

Pin `FS_METHOD` to `direct` (overridable via env). The Direct transport reads the
file without the write probe, eliminating the fatal. This also hardens any other
`WP_Filesystem` read paths against the same fallback.

## Notes

- Logging was **not** disabled — the host's PHP `error_log` was already capturing
  fatals in the docroot.
- Takes effect on the next tagged deploy.