### PR TITLE
feat(sentry): server-side error monitoring (PHP-only)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,9 @@ WP_DEBUG_DISPLAY=false
 # Leave empty to disable. Set only in production's .env.
 # PHP-only by design — do NOT add a browser DSN (it would require consent).
 WP_SENTRY_PHP_DSN=''
+# Optional tuning (defaults: traces 1.0 = 100% sampling, logs enabled).
+# WP_SENTRY_TRACES_SAMPLE_RATE=1.0
+# WP_SENTRY_ENABLE_LOGS=true
 
 # Optional
 # DISABLE_WP_CRON=true

--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,11 @@ WP_DEBUG=true
 WP_DEBUG_LOG=true
 WP_DEBUG_DISPLAY=false
 
+# Sentry error monitoring (server-side / PHP only).
+# Leave empty to disable. Set only in production's .env.
+# PHP-only by design — do NOT add a browser DSN (it would require consent).
+WP_SENTRY_PHP_DSN=''
+
 # Optional
 # DISABLE_WP_CRON=true
 # WP_MEMORY_LIMIT='256M'

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@
 !/web/app/mu-plugins/security-headers.php
 !/web/app/mu-plugins/robots-content-signal.php
 !/web/app/mu-plugins/hreflang-x-default.php
+!/web/app/mu-plugins/sentry-admin-context.php
 
 # Uploads
 /web/app/uploads/*

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,8 @@
     "apermo/apermo-notify": "^0.1.1",
     "inpsyde/wp-translation-downloader": "^2.6",
     "wpackagist-plugin/statify": "^1.8",
-    "wpackagist-plugin/performant-translations": "^1.2"
+    "wpackagist-plugin/performant-translations": "^1.2",
+    "wpackagist-plugin/wp-sentry-integration": "^8.11"
   },
   "require-dev": {
     "apermo/apermo-coding-standards": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b976c11c38f2adc6257b077ce5637570",
+    "content-hash": "3e401e3ba6b08a0c8ae215fbcbd15979",
     "packages": [
         {
             "name": "apermo/apermo-notify",
@@ -1821,6 +1821,24 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/wp-force-login/"
+        },
+        {
+            "name": "wpackagist-plugin/wp-sentry-integration",
+            "version": "8.11.1",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/wp-sentry-integration/",
+                "reference": "tags/8.11.1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/wp-sentry-integration.8.11.1.zip"
+            },
+            "require": {
+                "composer/installers": "^1.0 || ^2.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/wp-sentry-integration/"
         },
         {
             "name": "wpackagist-plugin/wp-test-email",

--- a/config/application.php
+++ b/config/application.php
@@ -129,6 +129,25 @@ Config::define('SAVEQUERIES', env('SAVEQUERIES') ?: false);
 ini_set('display_errors', '0');
 
 /**
+ * Sentry error monitoring (server-side only).
+ *
+ * PHP-only by design: no browser DSN is set, so no third-party JavaScript loads
+ * on the frontend and no client data leaves the browser, keeping the site
+ * consent-free. The DSN lives only in production's .env, so staging and local
+ * development stay silent without further configuration. PII is disabled, so
+ * visitor IPs and identities are never sent; administrators are enriched
+ * separately by the sentry-admin-context mu-plugin.
+ */
+$sentry_dsn = env('WP_SENTRY_PHP_DSN');
+if ($sentry_dsn) {
+    Config::define('WP_SENTRY_PHP_DSN', $sentry_dsn);
+    Config::define('WP_SENTRY_ENV', env('WP_SENTRY_ENV') ?: $env_type);
+    Config::define('WP_SENTRY_SEND_DEFAULT_PII', false);
+    Config::define('WP_SENTRY_TRACES_SAMPLE_RATE', 1.0);
+    Config::define('WP_SENTRY_ENABLE_LOGS', true);
+}
+
+/**
  * Allow WordPress CLI to work
  */
 if (defined('WP_CLI') && WP_CLI) {

--- a/config/application.php
+++ b/config/application.php
@@ -143,8 +143,14 @@ if ($sentry_dsn) {
     Config::define('WP_SENTRY_PHP_DSN', $sentry_dsn);
     Config::define('WP_SENTRY_ENV', env('WP_SENTRY_ENV') ?: $env_type);
     Config::define('WP_SENTRY_SEND_DEFAULT_PII', false);
-    Config::define('WP_SENTRY_TRACES_SAMPLE_RATE', 1.0);
-    Config::define('WP_SENTRY_ENABLE_LOGS', true);
+
+    // Tunable from .env without a redeploy; a null check (not ?:) keeps an
+    // explicit 0.0 sample rate or a false log toggle from falling back.
+    $sentry_traces_rate = env('WP_SENTRY_TRACES_SAMPLE_RATE');
+    Config::define('WP_SENTRY_TRACES_SAMPLE_RATE', $sentry_traces_rate !== null ? (float) $sentry_traces_rate : 1.0);
+
+    $sentry_enable_logs = env('WP_SENTRY_ENABLE_LOGS');
+    Config::define('WP_SENTRY_ENABLE_LOGS', $sentry_enable_logs !== null ? (bool) $sentry_enable_logs : true);
 }
 
 /**

--- a/web/app/mu-plugins/sentry-admin-context.php
+++ b/web/app/mu-plugins/sentry-admin-context.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Plugin Name: Sentry Admin Context
+ * Description: Attaches full user identity to Sentry events for administrators only.
+ */
+
+namespace Apermo\Sentry;
+
+add_filter( 'wp_sentry_user_context', __NAMESPACE__ . '\\enrich_admin_context' );
+
+/**
+ * Adds the current user's full identity to Sentry events for administrators.
+ *
+ * Visitors stay minimized: WP_SENTRY_SEND_DEFAULT_PII is false, and the WP Sentry
+ * plugin only resolves user context for logged-in users, passing non-admins just
+ * their numeric id. The sole administrator is both the data subject and the
+ * controller, so logging their own identity needs no consent and makes their own
+ * error reports actionable.
+ *
+ * @param array $user User context the WP Sentry plugin is about to send.
+ * @return array Possibly enriched user context.
+ */
+function enrich_admin_context( array $user ): array {
+	if ( ! current_user_can( 'manage_options' ) ) {
+		return $user;
+	}
+
+	$current = wp_get_current_user();
+
+	$user['id']         = $current->ID;
+	$user['name']       = $current->display_name;
+	$user['username']   = $current->user_login;
+	$user['email']      = $current->user_email;
+	$user['ip_address'] = isset( $_SERVER['REMOTE_ADDR'] )
+		? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) )
+		: null;
+
+	return $user;
+}

--- a/web/app/mu-plugins/sentry-admin-context.php
+++ b/web/app/mu-plugins/sentry-admin-context.php
@@ -21,7 +21,9 @@ add_filter( 'wp_sentry_user_context', __NAMESPACE__ . '\\enrich_admin_context' )
  * @return array Possibly enriched user context.
  */
 function enrich_admin_context( array $user ): array {
-	if ( ! current_user_can( 'manage_options' ) ) {
+	// mu-plugins load before pluggable functions, so an error captured very
+	// early in bootstrap could invoke this filter before current_user_can exists.
+	if ( ! \function_exists( 'current_user_can' ) || ! current_user_can( 'manage_options' ) ) {
 		return $user;
 	}
 


### PR DESCRIPTION
Adds [WP Sentry](https://wordpress.org/plugins/wp-sentry-integration/) (8.11.1)
for **server-side** error monitoring, configured entirely via `wp-config`
constants.

## Design

- **PHP-only.** No browser/JS DSN is set, so no third-party JavaScript loads on
  the frontend and no client data leaves the page. This keeps the site
  **consent-free by design** — no cookie/consent banner required.
- **Production-only.** Constants are defined only when `WP_SENTRY_PHP_DSN` is
  present in `.env`. Staging and local dev have no DSN, so the plugin stays
  inert there. The DSN lives only on the production server's `.env` (gitignored,
  excluded from deploy rsync).
- **Data minimization.** `WP_SENTRY_SEND_DEFAULT_PII` is `false`, so visitor IPs
  and identities are never sent. The DSN targets Sentry's **EU region**
  (`de.sentry.io`).
- **Admin enrichment.** A `sentry-admin-context` mu-plugin re-attaches full
  identity (name/email/username/IP) via the `wp_sentry_user_context` filter, but
  only for `manage_options` users. The sole admin is both data subject and
  controller, so logging their own data needs no consent.
- Performance tracing (`WP_SENTRY_TRACES_SAMPLE_RATE = 1.0`) and log forwarding
  (`WP_SENTRY_ENABLE_LOGS`) are enabled.

## GDPR

Compliant without consent: no ePrivacy storage on the device, lawful basis is
legitimate interest (Art. 6(1)(f), Recital 49 — information security), visitor
data minimized, EU residency.

## Rollout (manual, after merge + deploy)

1. Add `WP_SENTRY_PHP_DSN='<dsn>'` to the production server's `.env` via SSH.
2. Deploy (tag push `v*`).
3. `wp plugin activate wp-sentry-integration --network`.

## Non-code follow-ups

- Sign Sentry's DPA (in-dashboard).
- Add a privacy-policy line naming Sentry as a processor.
- Enable "Prevent Storing of IP Addresses" in the Sentry project settings.

## Notes

`config/application.php` follows Bedrock's 4-space style (240 pre-existing PHPCS
errors on `main`); the added block matches that file's style. The new mu-plugin
follows the Apermo ruleset.