### PR TITLE
feat(sentry): release tracking via deploy pipeline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,9 @@ WP_SENTRY_PHP_DSN=''
 # Optional tuning (defaults: traces 1.0 = 100% sampling, logs enabled).
 # WP_SENTRY_TRACES_SAMPLE_RATE=1.0
 # WP_SENTRY_ENABLE_LOGS=true
+# Release version. Normally written by the deploy pipeline (VERSION file);
+# set here only to override locally.
+# WP_SENTRY_VERSION=''
 
 # Optional
 # DISABLE_WP_CRON=true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,8 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
 
     steps:
       - name: Checkout repository
@@ -45,6 +47,22 @@ jobs:
         uses: apermo/sovereignty/.github/actions/build@v1.5.3
         with:
           working-directory: web/app/themes/sovereignty
+
+      - name: Determine release version
+        id: version
+        run: |
+          set -eu
+          # Tag deploys use the tag (e.g. v1.7.0); manual dispatches fall back
+          # to the short SHA. The VERSION file ships in the artifact so the
+          # running app tags Sentry events with the same string the
+          # sentry-release job reports.
+          if [ "$GITHUB_REF_TYPE" = "tag" ]; then
+            version="$GITHUB_REF_NAME"
+          else
+            version="$(git rev-parse --short HEAD)"
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          printf '%s\n' "$version" > VERSION
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v7
@@ -143,6 +161,33 @@ jobs:
             for url in $(wp site list --field=url); do
               wp cachify flush --all-methods --url="$url" || true
             done
+
+  sentry-release:
+    name: Create Sentry Release
+    runs-on: ubuntu-latest
+    needs: [build, deploy]
+    # Only tag deploys are real releases; workflow_dispatch on a branch is skipped.
+    if: startsWith(github.ref, 'refs/tags/v')
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          # Full history so set_commits can associate this release's commits.
+          fetch-depth: 0
+
+      - name: Create Sentry release and production deploy
+        uses: getsentry/action-release@v3
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: christoph-daum
+          SENTRY_PROJECT: chrdmde
+          # EU data region — without this sentry-cli defaults to the US host.
+          SENTRY_URL: https://de.sentry.io
+        with:
+          environment: production
+          version: ${{ needs.build.outputs.version }}
+          set_commits: auto
 
   release:
     name: Create GitHub Release

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Release version written by the deploy pipeline
+/VERSION
+
 # Dependency directories
 /vendor/
 

--- a/config/application.php
+++ b/config/application.php
@@ -156,8 +156,9 @@ if ($sentry_dsn) {
     // attributed to the deployed git tag; overridable via env. Without it the
     // plugin falls back to the active theme version.
     $sentry_release = env('WP_SENTRY_VERSION');
-    if (!$sentry_release && file_exists($root_dir . '/VERSION')) {
-        $sentry_release = trim((string) file_get_contents($root_dir . '/VERSION'));
+    $sentry_version_file = $root_dir . '/VERSION';
+    if (!$sentry_release && is_readable($sentry_version_file)) {
+        $sentry_release = trim((string) @file_get_contents($sentry_version_file));
     }
     if ($sentry_release) {
         Config::define('WP_SENTRY_VERSION', $sentry_release);

--- a/config/application.php
+++ b/config/application.php
@@ -151,6 +151,17 @@ if ($sentry_dsn) {
 
     $sentry_enable_logs = env('WP_SENTRY_ENABLE_LOGS');
     Config::define('WP_SENTRY_ENABLE_LOGS', $sentry_enable_logs !== null ? (bool) $sentry_enable_logs : true);
+
+    // Release: written into a VERSION file by the deploy pipeline so events are
+    // attributed to the deployed git tag; overridable via env. Without it the
+    // plugin falls back to the active theme version.
+    $sentry_release = env('WP_SENTRY_VERSION');
+    if (!$sentry_release && file_exists($root_dir . '/VERSION')) {
+        $sentry_release = trim((string) file_get_contents($root_dir . '/VERSION'));
+    }
+    if ($sentry_release) {
+        Config::define('WP_SENTRY_VERSION', $sentry_release);
+    }
 }
 
 /**


### PR DESCRIPTION
Ties Sentry releases to the deploy tag so issues are attributed to a release,
regressions are detected, and production deploys are marked. Events are
currently mis-tagged `release: 1.5.3` (the theme version — the plugin's
fallback when `WP_SENTRY_VERSION` is undefined); this fixes that.

## Changes

- **`config/application.php`** — defines `WP_SENTRY_VERSION` from a `VERSION`
  file written by the deploy pipeline (overridable via env). Falls back cleanly
  when absent (local/dev), so the plugin only stops using the theme version
  once a real deploy version is present.
- **`.github/workflows/deploy.yml`**
  - build job writes the deploy version into a `VERSION` file shipped in the
    artifact (git tag, or short SHA for manual `workflow_dispatch` runs) and
    exposes it as a job output.
  - new tag-gated `sentry-release` job uses `getsentry/action-release@v3` to
    create the release, associate commits (`set_commits: auto`), and mark a
    `production` deploy. `SENTRY_URL` pins the **EU** data region.
- **`.gitignore`** — ignores the build-generated `/VERSION`.
- **`.env.example`** — documents the optional `WP_SENTRY_VERSION` override.

## Required before this works

- Add the GitHub Actions secret **`SENTRY_AUTH_TOKEN`** (Sentry org token,
  scopes `project:releases` + `org:read`, created under the EU `christoph-daum`
  org). `SENTRY_ORG`/`SENTRY_PROJECT`/`SENTRY_URL` are hardcoded in the workflow.

## Related (dashboard, separate from this PR)

- Sentry↔GitHub integration (commits/suspect-commits/source links + GitHub issue
  management).
- Disable Seer org-wide.

## Verification (after merge + a `v*` tag)

- `find_releases` shows the tag with commits + a `production` deploy.
- A new event's `release` tag equals the deployed tag (no longer `1.5.3`).