### PR TITLE
chore: update sovereignty to v2.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "roots/bedrock-disallow-indexing": "^2.0",
     "roots/wordpress": "7.*",
     "roots/wp-config": "^1.0",
-    "apermo/sovereignty": "^1.5.3",
+    "apermo/sovereignty": "^2.0.0",
     "wpackagist-plugin/activitypub": "^9.0",
     "wpackagist-plugin/antispam-bee": "^2.11",
     "wpackagist-plugin/basepress": "^2.17",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3e401e3ba6b08a0c8ae215fbcbd15979",
+    "content-hash": "36b2415a84b5308bd8f9f1cd625662df",
     "packages": [
         {
             "name": "apermo/apermo-notify",
@@ -107,16 +107,16 @@
         },
         {
             "name": "apermo/sovereignty",
-            "version": "1.5.3",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/apermo/sovereignty.git",
-                "reference": "8c0ef8572a34003e718eb6ffe2e9df7d847d1e11"
+                "reference": "184d94b0052cc91e2b6724b74a59717d26bed265"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/apermo/sovereignty/zipball/8c0ef8572a34003e718eb6ffe2e9df7d847d1e11",
-                "reference": "8c0ef8572a34003e718eb6ffe2e9df7d847d1e11",
+                "url": "https://api.github.com/repos/apermo/sovereignty/zipball/184d94b0052cc91e2b6724b74a59717d26bed265",
+                "reference": "184d94b0052cc91e2b6724b74a59717d26bed265",
                 "shasum": ""
             },
             "require": {
@@ -202,7 +202,7 @@
                 "issues": "https://github.com/apermo/sovereignty/issues",
                 "source": "https://github.com/apermo/sovereignty"
             },
-            "time": "2026-06-04T05:36:42+00:00"
+            "time": "2026-06-15T15:07:26+00:00"
         },
         {
             "name": "composer/installers",


### PR DESCRIPTION
Updates the Sovereignty theme from `v1.5.3` to `v2.0.0`.

Bumps the constraint in `composer.json` from `^1.5.3` to `^2.0.0` (major
release, so the caret had to be widened) and regenerates `composer.lock`.

## Heads-up: major version

`v2.0.0` is a major bump and carries a substantial visual/markup rework.
Worth a visual check before release:

- refactor(css): semantic CSS custom properties
- feat(css): terminal-style form fields
- feat(header): animated terminal logo + SVG helper
- feat(theme): radial gradient body + meta-nav scaffold
- feat(theme): terminal-chrome content separator
- feat(footer): separator divider + reworded credit
- fix: header divider, page-banner jump, share button
- fix(a11y): accessibility pass (axe findings)
- feat(a11y): high contrast & reduced motion
- feat(style): cross-document view transitions

Full changelog: https://github.com/apermo/sovereignty/compare/v1.5.3...v2.0.0

## Deploy note

No deploy is triggered by merging this. A `v*` tag (or manual dispatch) is
required to ship it to production.