### PR TITLE
fix(deploy): keep .well-known writable for AutoSSL

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -140,6 +140,13 @@ jobs:
             # dir here the same way uploads/ is handled — see issue #33.
             find . -path ./web/app/uploads -prune -o -name .env -prune -o -type d -exec chmod 555 {} +
             find . -path ./web/app/uploads -prune -o -name .env -prune -o -type f -exec chmod 444 {} +
+            # AutoSSL/Let's Encrypt renews certs via HTTP DCV by creating
+            # web/.well-known/acme-challenge and dropping a token there. The
+            # read-only hardening above locks .well-known to 555, so the write
+            # fails and every domain's cert silently stops renewing. Re-open
+            # just this one directory to 755 (owner-writable); security.txt
+            # inside it stays 444 from the find above.
+            chmod 755 web/.well-known
             if [ -f ".env" ]; then
               chmod 600 .env
             fi


### PR DESCRIPTION
## Problem

The post-deploy hardening step locks the whole deployed tree read-only:

```sh
find . -path ./web/app/uploads -prune -o -name .env -prune -o -type d -exec chmod 555 {} +
```

This includes `web/.well-known`, so cPanel AutoSSL / Let's Encrypt cannot
create `web/.well-known/acme-challenge/` to drop its HTTP DCV token. DCV then
fails for **every domain on the account** with:

> The system failed to create the directory
> `/home/.../public_html/.well-known/acme-challenge` because of an error:
> Permission denied

Existing certs kept working only because they were issued before the tree was
locked; renewals silently fail, and newly parked domains never get a cert.
This surfaced when adding `translate.chrdm.de` (the GlotPress/Traduttore subsite
from #74), whose AutoSSL DCV failed.

## Fix

Re-open just `web/.well-known` to `755` after the hardening so AutoSSL can write
its challenge token. The directory's contents (`security.txt`) stay `444` from
the `find` above; nothing else in the tree becomes writable.

## Verification

Applied the equivalent `chmod 755 web/.well-known` live on prod, re-ran AutoSSL,
and confirmed:

- `http://translate.chrdm.de/.well-known/acme-challenge/<token>` serves `200`
  over plain HTTP (ACME-style fetch).
- A fresh Let's Encrypt cert issued covering `translate.chrdm.de`
  (`tls_verify=0`, valid Jun 15 → Sep 13).

Without this change the next deploy would re-lock `.well-known` and break
renewals again for all domains.