### PR TITLE
feat(i18n): stand up translate subsite (GlotPress + Traduttore)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 # Themes - ignore all, whitelist custom
 /web/app/themes/*
 !/web/app/themes/.gitkeep
+!/web/app/themes/glotpress-blank/
 # !/web/app/themes/my-custom-theme/
 
 # Plugins - ignore all, whitelist custom

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,9 @@
     "inpsyde/wp-translation-downloader": "^2.6",
     "wpackagist-plugin/statify": "^1.8",
     "wpackagist-plugin/performant-translations": "^1.2",
-    "wpackagist-plugin/wp-sentry-integration": "^8.11"
+    "wpackagist-plugin/wp-sentry-integration": "^8.11",
+    "wpackagist-plugin/glotpress": "^4.0",
+    "wearerequired/traduttore": "^3.2"
   },
   "require-dev": {
     "apermo/apermo-coding-standards": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "36b2415a84b5308bd8f9f1cd625662df",
+    "content-hash": "4c523e96f3f5093c97c8fb4964af0783",
     "packages": [
         {
             "name": "apermo/apermo-notify",
@@ -1373,6 +1373,164 @@
             "time": "2025-12-27T19:49:13+00:00"
         },
         {
+            "name": "wearerequired/traduttore",
+            "version": "3.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/wearerequired/traduttore.git",
+                "reference": "65e08d6dccbb944f5c094bba3d277b1874f0b89a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wearerequired/traduttore/zipball/65e08d6dccbb944f5c094bba3d277b1874f0b89a",
+                "reference": "65e08d6dccbb944f5c094bba3d277b1874f0b89a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-zip": "*",
+                "php": ">=7.1",
+                "wearerequired/traduttore-registry": "^2.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
+                "php-stubs/wp-cli-stubs": "^2.4",
+                "phpunit/phpunit": "^7.5.20",
+                "szepeviktor/phpstan-wordpress": "^1.0.2",
+                "wearerequired/coding-standards": "^1.5",
+                "wp-cli/extension-command": "^2.0",
+                "wp-cli/rewrite-command": "^2.0",
+                "wp-cli/wp-cli-tests": "^3.0.11",
+                "wpackagist-plugin/glotpress": "^2.3.1"
+            },
+            "suggest": {
+                "wpackagist-plugin/slack": "Send Slack notifications for various events"
+            },
+            "type": "wordpress-plugin",
+            "extra": {
+                "webroot-dir": "app/wordpress-core",
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                },
+                "installer-paths": {
+                    "vendor/wordpress-plugin/{$name}/": [
+                        "type:wordpress-plugin"
+                    ]
+                },
+                "webroot-package": "wordpress/wordpress"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Required\\Traduttore\\": "inc"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "required",
+                    "email": "info@required.ch",
+                    "homepage": "https://required.com",
+                    "role": "Company"
+                },
+                {
+                    "name": "Dominik Schilling",
+                    "email": "dominik@required.ch",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Ulrich Pogson",
+                    "email": "ulrich@required.ch",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Pascal Birchler",
+                    "role": "Developer"
+                }
+            ],
+            "description": "WordPress.org-style translation API for your WordPress projects.",
+            "homepage": "https://github.com/wearerequired/traduttore",
+            "keywords": [
+                "glotpress",
+                "translations",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/wearerequired/traduttore/issues",
+                "source": "https://github.com/wearerequired/traduttore/tree/3.2.0"
+            },
+            "time": "2022-01-18T17:05:00+00:00"
+        },
+        {
+            "name": "wearerequired/traduttore-registry",
+            "version": "2.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/wearerequired/traduttore-registry.git",
+                "reference": "0a267c7e12928a17360f6157d358cc2a169734a1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wearerequired/traduttore-registry/zipball/0a267c7e12928a17360f6157d358cc2a169734a1",
+                "reference": "0a267c7e12928a17360f6157d358cc2a169734a1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
+                "phpunit/phpunit": "^7.5.13",
+                "wearerequired/coding-standards": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "inc/namespace.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "required",
+                    "email": "support@required.ch",
+                    "homepage": "https://required.com",
+                    "role": "Company"
+                },
+                {
+                    "name": "Dominik Schilling",
+                    "email": "dominik@required.ch",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Pascal Birchler",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Allows loading translation files from a custom GlotPress site running Traduttore",
+            "homepage": "https://github.com/wearerequired/traduttore-registry",
+            "keywords": [
+                "glotpress",
+                "translations",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/wearerequired/traduttore-registry/issues",
+                "source": "https://github.com/wearerequired/traduttore-registry/tree/2.1.3"
+            },
+            "time": "2020-09-12T11:59:14+00:00"
+        },
+        {
             "name": "wpackagist-plugin/activitypub",
             "version": "9.0.1",
             "source": {
@@ -1569,6 +1727,24 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/gatherpress/"
+        },
+        {
+            "name": "wpackagist-plugin/glotpress",
+            "version": "4.0.3",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/glotpress/",
+                "reference": "tags/4.0.3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/glotpress.4.0.3.zip"
+            },
+            "require": {
+                "composer/installers": "^1.0 || ^2.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/glotpress/"
         },
         {
             "name": "wpackagist-plugin/hum",

--- a/web/app/themes/glotpress-blank/functions.php
+++ b/web/app/themes/glotpress-blank/functions.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * GlotPress Blank theme setup.
+ *
+ * @package GlotPress_Blank
+ */
+
+namespace Apermo\GlotPressBlank;
+
+/**
+ * Redirects the subsite front page to the GlotPress home.
+ *
+ * The translate.chrdm.de front page has no content of its own; GlotPress is
+ * mounted under its default /glotpress/ base. Sending the bare domain there
+ * lets visitors land on the translation UI instead of an empty WordPress page.
+ * Only the front page is redirected — wp-admin, the REST API (including the
+ * Traduttore webhook at /wp-json/) and GlotPress's own routes are untouched,
+ * which is why GlotPress is left at /glotpress/ rather than mounted at root.
+ */
+function redirect_front_page_to_glotpress() {
+	if ( ! \is_front_page() ) {
+		return;
+	}
+
+	$glotpress_url = \function_exists( 'gp_url_public_root' )
+		? \gp_url_public_root()
+		: \home_url( '/glotpress/' );
+
+	\wp_safe_redirect( $glotpress_url, 302 );
+	exit;
+}
+\add_action( 'template_redirect', __NAMESPACE__ . '\\redirect_front_page_to_glotpress' );

--- a/web/app/themes/glotpress-blank/index.php
+++ b/web/app/themes/glotpress-blank/index.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Front controller for the GlotPress Blank theme.
+ *
+ * Renders nothing by design. The translate.chrdm.de subsite serves GlotPress
+ * and the Traduttore REST API, neither of which uses the active theme. A
+ * request that reaches this template is outside GlotPress, so it returns an
+ * empty document instead of exposing an unstyled WordPress page.
+ *
+ * @package GlotPress_Blank
+ */

--- a/web/app/themes/glotpress-blank/style.css
+++ b/web/app/themes/glotpress-blank/style.css
@@ -1,0 +1,13 @@
+/*
+Theme Name: GlotPress Blank
+Theme URI: https://github.com/apermo/chrdm.de
+Author: Christoph Daum
+Author URI: https://christoph-daum.de
+Description: Minimal blank theme for the translate.chrdm.de subsite. GlotPress renders its own UI and Traduttore exposes a REST API, both independent of the active theme; this theme exists only to satisfy WordPress's active-theme requirement and intentionally renders no front end.
+Version: 1.0.0
+Requires at least: 6.4
+Requires PHP: 8.3
+License: GPL-2.0-or-later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
+Text Domain: glotpress-blank
+*/


### PR DESCRIPTION
Stands up the `translate.chrdm.de` translation subsite. Part of the platform epic #74; implements #77 (+ the blank-theme groundwork).

## Changes

**1. GlotPress + Traduttore via Composer**
- `wpackagist-plugin/glotpress` `^4.0` (4.0.3) — translation UI + read-only `/api/translations/` endpoint
- `wearerequired/traduttore` `^3.2` (3.2.0) — clone-on-webhook, `wp i18n make-pot`, build language packs
- Pulls in `wearerequired/traduttore-registry` (2.1.3) as a dep. Only `composer.json`/`composer.lock` change; plugin files land in gitignored `web/app/plugins/`.

**2. Blank theme `glotpress-blank`** (`web/app/themes/glotpress-blank/`, gitignore-whitelisted)
- `style.css` + `index.php` (renders nothing). GlotPress and Traduttore render their own output independent of the theme; this only satisfies WP's active-theme requirement. This install uses `roots/wordpress-no-content`, so there's no bundled default theme to fall back on.

**3. Front-page redirect** (`functions.php`)
- `template_redirect` sends the subsite front page → GlotPress home (`gp_url_public_root()`), so visiting `translate.chrdm.de` lands on the translation UI.

## Why GlotPress stays at /glotpress/ (not root)

GlotPress's empty-base rewrite (`rewrite.php`) registers a catch-all `^(.*)$ → index.php?gp_route=...` at `top` priority, which would intercept `/wp-json/` — the path Traduttore's GitHub webhook (`/wp-json/traduttore/v1/incoming-webhook`) uses. Keeping the default `/glotpress/` base + a front-page redirect gives the same land-on-GlotPress UX with zero risk to REST, the webhook, or wp-admin.

## Out of scope (later issues)

- Per-site activation on the translate subsite (server)
- `TRADUTTORE_GITHUB_SYNC_SECRET` + queue cron → #78
- Consumer wiring via `wp-translation-downloader` `api.names` → #89/#90

Deploys fire only on a `v*` tag, so merging ships nothing until the next release; plugins arrive inactive until activated on the subsite.