### PR TITLE
feat(i18n): wire Traduttore secret + WP-CLI bin config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,13 @@ WP_SENTRY_PHP_DSN=''
 # set here only to override locally.
 # WP_SENTRY_VERSION=''
 
+# Traduttore translation server (translate.chrdm.de subsite only).
+# Set only in production's .env. The sync secret must match the GitHub
+# webhook configured on each translated repo; TRADUTTORE_WP_BIN is the
+# WP-CLI path Traduttore shells out to (defaults to /usr/local/bin/wp).
+# TRADUTTORE_GITHUB_SYNC_SECRET=''
+# TRADUTTORE_WP_BIN='/usr/local/bin/wp'
+
 # Optional
 # DISABLE_WP_CRON=true
 # WP_MEMORY_LIMIT='256M'

--- a/config/application.php
+++ b/config/application.php
@@ -166,6 +166,21 @@ if ($sentry_dsn) {
 }
 
 /**
+ * Traduttore translation server (translate.chrdm.de subsite only).
+ *
+ * The sync secret authenticates GitHub webhook pushes and lives only in
+ * production's .env, so staging and local development stay inert and no empty
+ * constant leaks onto sites where the plugin is inactive. Traduttore shells out
+ * to WP-CLI for its clone/make-pot/build pipeline, so it needs the binary path
+ * on this host; that constant is only defined alongside the secret.
+ */
+$traduttore_secret = env('TRADUTTORE_GITHUB_SYNC_SECRET');
+if ($traduttore_secret) {
+    Config::define('TRADUTTORE_GITHUB_SYNC_SECRET', $traduttore_secret);
+    Config::define('TRADUTTORE_WP_BIN', env('TRADUTTORE_WP_BIN') ?: '/usr/local/bin/wp');
+}
+
+/**
  * Allow WordPress CLI to work
  */
 if (defined('WP_CLI') && WP_CLI) {


### PR DESCRIPTION
Implements the **config half of #78** (part of epic #74).

## What

`config/application.php` now defines two Traduttore constants from `.env`, and `.env.example` documents them:

- `TRADUTTORE_GITHUB_SYNC_SECRET` — authenticates GitHub webhook pushes
- `TRADUTTORE_WP_BIN` — the WP-CLI path Traduttore `exec()`s for its clone → `make-pot` → build pipeline (`/usr/local/bin/wp` on this host, per the #75 spike)

The block is **guarded on the secret being present**, mirroring the Sentry block: the constants only exist where the secret is configured (the production translate subsite) and never leak onto staging, local dev, or the main site.

## Why these two

Traduttore's flow (verified in the installed source):
- webhook → `wp_schedule_single_event('traduttore.update', …)` on the translate subsite (`inc/Updater.php`)
- that event `exec()`s a detached `wp` process via `get_wp_bin()` → honors `TRADUTTORE_WP_BIN` (`inc/Updater.php:223`)
- webhook auth uses `TRADUTTORE_GITHUB_SYNC_SECRET`

## Server-side follow-ups (NOT in this PR — they're not committable)

1. **Set the value** in production's `.env`: a strong `TRADUTTORE_GITHUB_SYNC_SECRET` (+ `TRADUTTORE_WP_BIN='/usr/local/bin/wp'`). `.env` is gitignored and read every request, so it takes effect once this PR's `application.php` is deployed.
2. **Cron for the translate subsite.** The existing crontab runs `wp-cron.php` only for the main site, so Traduttore's `traduttore.update` / `traduttore.generate_zip` events on `translate.chrdm.de` wouldn't drain. Add e.g.:
   ```cron
   */5 * * * * cd /home/<user>/chrdm-bedrock && /usr/local/bin/wp cron event run --due-now --url=https://translate.chrdm.de --quiet
   ```
3. The same secret value goes into each repo's GitHub webhook (#81).

Outbound GitHub clone was already confirmed working in the #75 spike. Nothing deploys until a `v*` tag.