### PR TITLE
fix(config): let WP-CLI --url target subsites

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -181,9 +181,16 @@ if ($traduttore_secret) {
 }
 
 /**
- * Allow WordPress CLI to work
+ * Allow WordPress CLI to work.
+ *
+ * WP-CLI has no HTTP request, so multisite bootstrap fatals unless HTTP_HOST is
+ * set. Default it to the network's main domain — but only when WP-CLI has not
+ * already set it from --url. Overwriting it unconditionally clobbers --url and
+ * forces every command onto the main site, which makes subsite targeting
+ * impossible (e.g. draining the translate.chrdm.de Traduttore queue or running
+ * `wp traduttore` against that subsite).
  */
-if (defined('WP_CLI') && WP_CLI) {
+if (defined('WP_CLI') && WP_CLI && empty($_SERVER['HTTP_HOST'])) {
     $_SERVER['HTTP_HOST'] = Config::get('DOMAIN_CURRENT_SITE');
 }
 


### PR DESCRIPTION
## Problem

`config/application.php` set `$_SERVER['HTTP_HOST'] = DOMAIN_CURRENT_SITE` for **every** WP-CLI invocation. WP-CLI derives the target host from `--url` *before* `wp-config` loads, so this overwrite clobbered it — and every `wp` command ran against the main site (blog 1) regardless of `--url`.

Verified on prod: `wp option get blogname --url=https://translate.chrdm.de/` (and `kb.chrdm.de`, `freunde.…`) all return the **main** site's `blogname`/`siteurl`.

### Impact
- The translate.chrdm.de Traduttore queue can't be drained — `wp cron event run --url=https://translate.chrdm.de` runs on the main site, so blog 6's `traduttore.update` / `traduttore.generate_zip` events never fire (breaks #78's cron).
- `wp traduttore project update|language-pack build --url=…` can't target the subsite (blocks #80/#82/#84 onboarding).
- Latent: the deploy's `for url in $(wp site list …); do wp cachify flush --url="$url"` loop only ever flushed the main site.

## Fix

Guard the default with `empty($_SERVER['HTTP_HOST'])` so it only applies as a fallback when WP-CLI did **not** set a host (i.e. no `--url`). `--url`-derived hosts are preserved, so subsite targeting works; plain `wp` commands still get the main-domain fallback and behave exactly as before.

```php
if (defined('WP_CLI') && WP_CLI && empty($_SERVER['HTTP_HOST'])) {
    $_SERVER['HTTP_HOST'] = Config::get('DOMAIN_CURRENT_SITE');
}
```

## Verification after deploy

`wp option get blogname --url=https://translate.chrdm.de/` should return the translate subsite (not "Christoph Daum"), and `wp traduttore info --url=https://translate.chrdm.de/` should run. `php -l` clean. Part of #74.