### PR TITLE
feat(i18n): store Traduttore packs under uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@
 !/web/app/mu-plugins/robots-content-signal.php
 !/web/app/mu-plugins/hreflang-x-default.php
 !/web/app/mu-plugins/sentry-admin-context.php
+!/web/app/mu-plugins/traduttore-content-dir.php
 
 # Uploads
 /web/app/uploads/*

--- a/web/app/mu-plugins/traduttore-content-dir.php
+++ b/web/app/mu-plugins/traduttore-content-dir.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Plugin Name: Traduttore Content Directory
+ * Description: Stores Traduttore language packs under uploads/ so they survive the read-only deploy hardening.
+ */
+
+namespace Apermo\Traduttore;
+
+add_filter( 'traduttore.content_dir', __NAMESPACE__ . '\\content_dir' );
+add_filter( 'traduttore.content_url', __NAMESPACE__ . '\\content_url' );
+
+/**
+ * Relocates Traduttore's language-pack cache into the uploads directory.
+ *
+ * Traduttore defaults to wp-content/traduttore, but the deploy locks the code
+ * tree read-only with only uploads/ left writable, so it can neither create
+ * nor write that directory. uploads/ is writable, survives every deploy and is
+ * web-accessible, which the downloadable packs require. Git clones are
+ * unaffected — Traduttore keeps those in the system temp directory.
+ *
+ * @param string $dir Default cache directory path.
+ * @return string Cache directory under uploads.
+ */
+function content_dir( string $dir ): string {
+	return wp_get_upload_dir()['basedir'] . '/traduttore';
+}
+
+/**
+ * Mirrors the cache relocation for the public language-pack download URL.
+ *
+ * Keeps the URL Traduttore advertises in its translations API in sync with
+ * content_dir(), so the consumer's translation downloader fetches packs from
+ * the uploads location rather than the unused wp-content default.
+ *
+ * @param string $url Default cache directory URL.
+ * @return string Cache URL under uploads.
+ */
+function content_url( string $url ): string {
+	return wp_get_upload_dir()['baseurl'] . '/traduttore';
+}


### PR DESCRIPTION
Part of epic #74; unblocks #80 onboarding.

## Problem

Traduttore stores language packs in `WP_CONTENT_DIR/traduttore` (`web/app/traduttore`) by default. But the deploy's read-only hardening locks every directory to `555` except `uploads/`, and `web/app` itself is `555` — so Traduttore can neither create nor write that cache dir. `wp traduttore language-pack build` (and the webhook-driven build) would fail. Verified on prod: `web/app` is `dr-xr-xr-x`, `web/app/traduttore` doesn't exist, `web/app/uploads` is `drwxr-xr-x`.

(Git clones are **not** affected — Traduttore's `Loader\Base::get_local_path()` puts those in `get_temp_dir()`, which is writable and not web-exposed.)

## Fix

A single-file mu-plugin filtering both Traduttore dir hooks to the subsite's uploads directory:

- `traduttore.content_dir` → `wp_get_upload_dir()['basedir'] . '/traduttore'`
- `traduttore.content_url` → `wp_get_upload_dir()['baseurl'] . '/traduttore'`

`uploads/` is the one location the deploy keeps writable (it's pruned from the hardening `find`), it persists across deploys, and it's web-accessible — exactly what downloadable packs need. Both hooks are filtered together so the path and the API-advertised download URL stay in sync.

Follows the existing mu-plugin conventions (single file, `Apermo\Traduttore` namespace, gitignore-whitelisted, third-person docblocks). `php -l` clean.

## Verification after deploy

`wp traduttore info --url=https://translate.chrdm.de/` should report the cache directory under `uploads/`, and `wp traduttore language-pack build <slug> --url=…` (during #80) should produce a downloadable pack served from that location.