### PR TITLE
feat(i18n): pull sovereignty packs from Traduttore

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -95,7 +95,12 @@
     "wordpress-install-dir": "web/wp",
     "wp-translation-downloader": {
       "languages": ["de_DE"],
-      "directory": "web/app/languages"
+      "directory": "web/app/languages",
+      "api": {
+        "names": {
+          "apermo/sovereignty": "https://translate.chrdm.de/glotpress/api/translations/sovereignty"
+        }
+      }
     }
   },
   "scripts": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4c523e96f3f5093c97c8fb4964af0783",
+    "content-hash": "9138db1d24e8830bb6a509e96aa1fbf4",
     "packages": [
         {
             "name": "apermo/apermo-notify",


### PR DESCRIPTION
Closes #89 (part of epic #74).

## What

Maps `apermo/sovereignty` to the self-hosted Traduttore endpoint in `composer.json` so `inpsyde/wp-translation-downloader` fetches the theme's German pack from our platform instead of wp.org (which has no pack for our custom theme):

```json
"extra": { "wp-translation-downloader": {
  "languages": ["de_DE"],
  "directory": "web/app/languages",
  "api": { "names": {
    "apermo/sovereignty": "https://translate.chrdm.de/glotpress/api/translations/sovereignty"
  }}
}}
```

Note the endpoint is under GlotPress's **`/glotpress/`** base (bare `/api/…` is 404).

## Verified end-to-end (locally)

`composer wp-translation-downloader:download --packages=apermo/sovereignty`:
```
sovereignty: found one translation. Installing...
→ web/app/languages/themes/sovereignty-de_DE.mo  (+ .po + JS .json)
```
Full chain confirmed: GlotPress/Traduttore builds the pack → API serves TranslationsPress JSON → downloader installs it. The pack ships at deploy time via `composer install`; the language files themselves are gitignored.

## composer.lock

Only the **content-hash** changes — the `api` block is downloader config, not a dependency, so no packages are added or updated. (`composer validate --strict` passes; the diff is a single line.)

## Out of scope

The GitHub webhook for auto-updates is #81 (separate, via `gh api`). Plugins (apermo-stash/notify) are #90.