### PR TITLE
fix(i18n): load .mo for Traduttore-managed domains

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@
 !/web/app/mu-plugins/hreflang-x-default.php
 !/web/app/mu-plugins/sentry-admin-context.php
 !/web/app/mu-plugins/traduttore-content-dir.php
+!/web/app/mu-plugins/apermo-translation-format.php
 
 # Uploads
 /web/app/uploads/*

--- a/web/app/mu-plugins/apermo-translation-format.php
+++ b/web/app/mu-plugins/apermo-translation-format.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Plugin Name: Apermo Translation File Format
+ * Description: Loads .mo directly for Traduttore-managed text domains so freshly deployed translations are never shadowed by a stale performant-translations .l10n.php cache.
+ */
+
+namespace Apermo\TranslationFormat;
+
+/**
+ * Text domains whose packs are built by the self-hosted GlotPress/Traduttore
+ * platform and redeployed on every release.
+ */
+const DOMAINS = array( 'sovereignty', 'apermo-stash', 'apermo-notify' );
+
+add_filter( 'translation_file_format', __NAMESPACE__ . '\\prefer_mo_for_managed_domains', 10, 2 );
+
+/**
+ * Forces the .mo format for the self-hosted, Traduttore-managed text domains.
+ *
+ * performant-translations compiles and prefers a .l10n.php cache next to each
+ * .mo. For these domains the pack is replaced on every deploy, and a stale
+ * .l10n.php from a previous build shadows the fresh .mo, so the site keeps
+ * serving outdated strings. Loading the .mo directly for them keeps them
+ * current; all other domains keep the .l10n.php optimisation.
+ *
+ * @param string $format Preferred translation file format.
+ * @param string $domain Text domain being loaded.
+ * @return string 'mo' for Traduttore-managed domains, the original format otherwise.
+ */
+function prefer_mo_for_managed_domains( $format, $domain ) {
+	return \in_array( $domain, DOMAINS, true ) ? 'mo' : $format;
+}


### PR DESCRIPTION
Part of epic #74. Fixes approved German translations not rendering on the live site for the sovereignty theme.

## Symptom

After approving German strings in GlotPress, rebuilding the pack (de_DE → 83%), and deploying, the live site still rendered the **old** strings. Verified with `wp eval`: `__('Site tools','sovereignty')` returned the English source, not `Website-Werkzeuge`.

## Root cause

`performant-translations` compiles a `.l10n.php` next to each `.mo` and **loads it in preference to the `.mo`**. The Traduttore pack zip ships only `.mo`/`.po`/`.json` (no `.l10n.php`), so performant-translations generates the `.l10n.php` consumer-side. A **stale `.l10n.php` from a previous build survives the deploy and shadows the freshly downloaded `.mo`** — confirmed on prod: the `.mo` (5736 bytes) contained the new German, but the `.l10n.php` (3465 bytes) did not, and WP served the stale cache.

## Fix

An mu-plugin filters performant-translations' per-domain `translation_file_format` hook to **`mo`** for the self-hosted, Traduttore-managed domains (`sovereignty`, `apermo-stash`, `apermo-notify`). WordPress then loads the `.mo` directly for them — always reflecting the deployed pack, immune to a stale `.l10n.php`. Every other text domain (WP core, third-party plugins) keeps the `.l10n.php` optimisation.

Surgical (3 domains), runtime (no deploy-pipeline change needed), and forward-safe for future translation updates. Follows the existing mu-plugin conventions (`Apermo\TranslationFormat` namespace, gitignore-whitelisted, third-person docblocks). `php -l` clean.

## Verification (after deploy)

`wp eval "echo __('Site tools','sovereignty');" --url=https://christoph-daum.de/` → `Website-Werkzeuge`, and the homepage footer renders `Diese Website läuft mit …`.

## Note

The alternative — having the deploy delete stale `.l10n.php` files — would touch `.github/workflows/deploy.yml`; this runtime mu-plugin is cleaner (domain-scoped, no deploy dependency) and is the same single-file mu-plugin pattern already used for `traduttore-content-dir`.