### PR TITLE
feat(i18n): pull plugin packs from Traduttore

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,10 +119,11 @@ exposes a TranslationsPress API; this site consumes them at deploy time via
 
 The only translation config in this repo is `composer.json` →
 `extra.wp-translation-downloader.api.names`, which maps a package to
-`https://translate.chrdm.de/glotpress/api/translations/<slug>` (note the `/glotpress/` base). Today only
-the `sovereignty` theme is wired there; the plugins are onboarded separately and may instead self-consume
-via the Traduttore Registry (see docs). Third-party plugins and core still translate from wp.org.
-Locales: **`de_DE` only**.
+`https://translate.chrdm.de/glotpress/api/translations/<slug>` (note the `/glotpress/` base). All three of
+our packages are wired there — the `sovereignty` theme and the `apermo-stash` / `apermo-notify` plugins —
+so chrdm.de consumes their packs at build time. Third-party plugins and core still translate from wp.org.
+Locales: **`de_DE` only**. The runtime Traduttore Registry is a deferred option, only relevant if the
+plugins ever run on installs outside chrdm.de (#102/#103) — not the planned path; see docs.
 
 Approved translations go live **only on a deploy** — rebuild the pack and run
 `gh workflow run deploy.yml`. Full architecture, server config, onboarding steps, WP-CLI commands, and

--- a/composer.json
+++ b/composer.json
@@ -98,7 +98,9 @@
       "directory": "web/app/languages",
       "api": {
         "names": {
-          "apermo/sovereignty": "https://translate.chrdm.de/glotpress/api/translations/sovereignty"
+          "apermo/sovereignty": "https://translate.chrdm.de/glotpress/api/translations/sovereignty",
+          "apermo/apermo-stash": "https://translate.chrdm.de/glotpress/api/translations/apermo-stash",
+          "apermo/apermo-notify": "https://translate.chrdm.de/glotpress/api/translations/apermo-notify"
         }
       }
     }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9138db1d24e8830bb6a509e96aa1fbf4",
+    "content-hash": "603d9270479a995e4d876a75dc88e79a",
     "packages": [
         {
             "name": "apermo/apermo-notify",

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -31,7 +31,7 @@ chrdm.de deploy: composer install
 ## Consumer wiring (the only translation code in this repo)
 
 `composer.json` → `extra.wp-translation-downloader.api.names` maps a package to the Traduttore endpoint;
-everything else still comes from wp.org. **Today only the `sovereignty` theme is wired here:**
+everything else still comes from wp.org. **All three of our packages are wired here:**
 
 ```json
 "wp-translation-downloader": {
@@ -39,24 +39,28 @@ everything else still comes from wp.org. **Today only the `sovereignty` theme is
   "directory": "web/app/languages",
   "api": {
     "names": {
-      "apermo/sovereignty": "https://translate.chrdm.de/glotpress/api/translations/sovereignty"
+      "apermo/sovereignty": "https://translate.chrdm.de/glotpress/api/translations/sovereignty",
+      "apermo/apermo-stash": "https://translate.chrdm.de/glotpress/api/translations/apermo-stash",
+      "apermo/apermo-notify": "https://translate.chrdm.de/glotpress/api/translations/apermo-notify"
     }
   }
 }
 ```
 
-The plugins (`apermo-stash`, `apermo-notify`) are **not** wired here yet — they're onboarded separately
-(build-time via this same `api.names` map, #90) and will more likely self-consume on any install via the
-runtime Traduttore Registry (next section; #102, #103). Add an entry per package as each is onboarded.
+This is chrdm.de-only, build-time consumption (#90). The runtime Traduttore Registry (next section) is a
+deferred future option, only relevant if the plugins ever run on installs outside chrdm.de (#102, #103) —
+not the planned path. Add an entry per package as each is onboarded.
 
 The endpoint includes the **`/glotpress/`** base — the bare `/api/translations/…` path is a 404. After
 changing `api.names`, run `composer install` locally and commit `composer.lock` (the `extra` block only
 bumps the lock's content-hash; no packages change). `wp-translation-downloader.lock` is gitignored —
 the server regenerates it on deploy.
 
-## Runtime consumption — Traduttore Registry (installs outside chrdm.de)
+## Runtime consumption — Traduttore Registry (deferred; installs outside chrdm.de)
 
-The `api.names` wiring above is **build-time and project-scoped**: it only delivers translations to a
+This is a **deferred future option** (#102, #103) — only pursued if a plugin ever needs to run off
+chrdm.de; the planned path is the `api.names` wiring above. The `api.names` wiring is **build-time and
+project-scoped**: it only delivers translations to a
 project whose `composer.json` opts in (i.e. chrdm.de). A plugin/theme installed on **another site** —
 manually, as a ZIP, or via a different Composer project — gets nothing from it.
 


### PR DESCRIPTION
Wires chrdm.de to consume the self-hosted Traduttore/GlotPress translation
packs for two plugins:

- `apermo/apermo-stash` → `https://translate.chrdm.de/glotpress/api/translations/apermo-stash`
- `apermo/apermo-notify` → `https://translate.chrdm.de/glotpress/api/translations/apermo-notify`

Both are added to `extra.wp-translation-downloader.api.names` alongside the
existing `apermo/sovereignty` entry, so `inpsyde/wp-translation-downloader`
fetches their `de_DE` packs from `translate.chrdm.de` on install/deploy.

### Notes

- The GlotPress projects exist and have had their originals imported via
  Traduttore, but are **0% translated**, so the API endpoints currently
  return empty packs (`{"translations":[]}`). The downloader handles this
  gracefully ("found no translations", 0 failed). Packs will populate once
  translations are added in GlotPress.
- This is an `extra`-only change, so only `composer.lock`'s `content-hash`
  changes — no dependency versions move.
- GitHub `push` webhooks pointing at the Traduttore incoming-webhook endpoint
  were added to both plugin repos, so future pushes auto-rebuild.

Closes #90.
