### PR TITLE
Switch page cache to Cachify HDD (filesystem) method

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -108,7 +108,7 @@ jobs:
       - name: Deploy via rsync
         uses: burnett01/rsync-deployments@8.0.5
         with:
-          switches: -avzr --delay-updates --delete-delay --chmod=D755,F644 --exclude='.env' --exclude='web/app/uploads/' --exclude='web/.htaccess'
+          switches: -avzr --delay-updates --delete-delay --chmod=D755,F644 --exclude='.env' --exclude='web/app/uploads/' --exclude='web/app/cache/' --exclude='web/.htaccess'
           path: build/
           remote_path: ${{ secrets.DEPLOY_PATH }}
           remote_host: ${{ secrets.DEPLOY_HOST }}
@@ -126,9 +126,12 @@ jobs:
           script: |
             set -eu
             cd ${{ secrets.DEPLOY_PATH }}
-            if [ -d "web/app/cache" ]; then
-              rm -rf web/app/cache/*
-            fi
+            # Cachify HDD method writes static page cache to web/app/cache. The
+            # dir is rsync-excluded so it survives deploys, but rsync does not
+            # invalidate it, so clear stale entries here. Ensure it exists so
+            # the cache-dir prune below has a target on a fresh server.
+            mkdir -p web/app/cache
+            rm -rf web/app/cache/*
             # performant-translations loads a compiled .l10n.php in preference
             # to the .mo. A stale .l10n.php from a previous build survives the
             # deploy and shadows the freshly downloaded translations, so the
@@ -149,10 +152,10 @@ jobs:
             # web/.htaccess is rsync-excluded but still locked to 444 here on
             # purpose (it falls under the find); runtime permalink rewrites need
             # a manual unlock — see the trade-off in .gemini/styleguide.md.
-            # When adding file-based object/page caching, whitelist the cache
-            # dir here the same way uploads/ is handled — see issue #33.
-            find . -path ./web/app/uploads -prune -o -name .env -prune -o -type d -exec chmod 555 {} +
-            find . -path ./web/app/uploads -prune -o -name .env -prune -o -type f -exec chmod 444 {} +
+            # web/app/cache holds the Cachify HDD page cache and must stay
+            # owner-writable at runtime, so it is pruned like uploads/ (#33).
+            find . -path ./web/app/uploads -prune -o -path ./web/app/cache -prune -o -name .env -prune -o -type d -exec chmod 555 {} +
+            find . -path ./web/app/uploads -prune -o -path ./web/app/cache -prune -o -name .env -prune -o -type f -exec chmod 444 {} +
             # AutoSSL/Let's Encrypt renews certs via HTTP DCV by creating
             # web/.well-known/acme-challenge and dropping a token there. The
             # read-only hardening above locks .well-known to 555, so the write

--- a/web/.htaccess
+++ b/web/.htaccess
@@ -9,6 +9,48 @@ RewriteRule ^([_0-9a-zA-Z-]+/)?files/(.+) wp-includes/ms-files.php?file=$2 [L]
 # Add trailing slash to /wp-admin
 RewriteRule ^([_0-9a-zA-Z-]+/)?wp-admin$ $1wp-admin/ [R=301,L]
 
+# Cachify HDD method: serve the static page cache before WordPress boots.
+# The absolute cache path is prod-specific and this file is rsync-excluded, so
+# the live copy on the server is authoritative and maintained manually; this
+# block is kept here for parity. Only matches GET requests for text/html with
+# no query string and no auth cookie, so ActivityPub (application/activity+json)
+# falls through to PHP.
+# BEGIN CACHIFY
+<IfModule mod_rewrite.c>
+  RewriteEngine on
+
+  # set hostname directory
+  RewriteCond %{HTTPS} on
+  RewriteRule .* - [E=CACHIFY_HOST:https-%{HTTP_HOST}]
+  RewriteCond %{HTTPS} off
+  RewriteRule .* - [E=CACHIFY_HOST:%{HTTP_HOST}]
+
+  # set subdirectory
+  RewriteCond %{REQUEST_URI} /$
+  RewriteRule .* - [E=CACHIFY_DIR:%{REQUEST_URI}]
+  RewriteCond %{REQUEST_URI} ^$
+  RewriteRule .* - [E=CACHIFY_DIR:/]
+
+  # gzip
+  RewriteRule .* - [E=CACHIFY_SUFFIX:]
+  <IfModule mod_mime.c>
+    RewriteCond %{HTTP:Accept-Encoding} gzip
+    RewriteRule .* - [E=CACHIFY_SUFFIX:.gz]
+    AddType text/html .gz
+    AddEncoding gzip .gz
+  </IfModule>
+
+  # Main Rules
+  RewriteCond %{HTTP_ACCEPT} .*text/html.*
+  RewriteCond %{REQUEST_METHOD} GET
+  RewriteCond %{QUERY_STRING} ^$
+  RewriteCond %{REQUEST_URI} !^/(wp-admin|wp-content/cache)/.*
+  RewriteCond %{HTTP_COOKIE} !(wp-postpass|wordpress_logged_in|comment_author)_
+  RewriteCond /home/neeehgky/chrdm-bedrock/web/app/cache/cachify/%{ENV:CACHIFY_HOST}%{ENV:CACHIFY_DIR}index.html%{ENV:CACHIFY_SUFFIX} -f
+  RewriteRule ^(.*) /app/cache/cachify/%{ENV:CACHIFY_HOST}%{ENV:CACHIFY_DIR}index.html%{ENV:CACHIFY_SUFFIX} [L]
+</IfModule>
+# END CACHIFY
+
 # WordPress front controller
 RewriteCond %{REQUEST_FILENAME} -f [OR]
 RewriteCond %{REQUEST_FILENAME} -d


### PR DESCRIPTION
Switches the anonymous page cache from Cachifys **Database** method to the **HDD (filesystem)** method, so cached pages are served as static HTML by the web server *before* WordPress boots.

## Why

Investigation under #107 showed the DB method served cache only ~24 ms faster than a miss: it serves at `template_redirect`, after WordPress and all plugins have already booted (~300 ms on this host). The HDD method serves the static file directly from `.htaccess`, bypassing PHP entirely — TTFB should drop to well under 100 ms on a hit.

The HDD rewrite keeps `RewriteCond %{HTTP_ACCEPT} .*text/html.*`, so ActivityPub (`application/activity+json`) and other non-HTML requests fall through to PHP and content negotiation is preserved.

## Changes

- **`web/.htaccess`** — add the `# BEGIN/END CACHIFY` block (rsync-excluded; the live prod copy is authoritative and maintained manually, this is kept for parity — the absolute cache path is prod-specific).
- **`.github/workflows/deploy.yml`** — `web/app/cache` is now rsync-excluded and pruned from the post-deploy read-only lockdown (mirroring `uploads/`), so the filesystem cache survives deploys and stays owner-writable. Without this the lockdown re-locks the tree to 555/444 and `--delete-delay` wipes the cache dir, silently disabling caching.

## Prod

The live `web/.htaccess` edit, cache-dir creation, and Cachify method switch are applied directly on the server (`.htaccess` is rsync-excluded). Verified after applying: HTTP 200, cache hit (Cachify signature, no `server-timing`), and ActivityPub JSON still served from PHP.

Closes #33.
Refs #107.