### PR TITLE
fix: disable Hum legacy FTL redirect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@
 !/web/app/mu-plugins/hreflang-x-default.php
 !/web/app/mu-plugins/sentry-admin-context.php
 !/web/app/mu-plugins/traduttore-content-dir.php
+!/web/app/mu-plugins/disable-hum-legacy-ftl.php
 
 # Uploads
 /web/app/uploads/*

--- a/web/app/mu-plugins/disable-hum-legacy-ftl.php
+++ b/web/app/mu-plugins/disable-hum-legacy-ftl.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Plugin Name: Disable Hum Legacy FTL Redirect
+ * Description: Stops Hum decoding arbitrary 404 paths as base-32 post IDs and 301-redirecting them.
+ */
+
+namespace Apermo\HumLegacyFtl;
+
+use Hum;
+
+add_action( 'init', __NAMESPACE__ . '\\disable_legacy_ftl_redirect', 20 );
+
+/**
+ * Removes Hum's legacy "Friendly Twitter Links" decoder from the hum_legacy_id filter.
+ *
+ * Hum's Hum::legacy_ftl_id() runs on every 404, strips non-hex characters from the request
+ * path and base_convert()s the remainder into a post ID to 301-redirect to. This hijacks
+ * ordinary URLs (e.g. /blog/ decodes to post 11) and throws a ValueError when a long junk
+ * path overflows base_convert() to INF on PHP 8. This site never used FTL shortlinks, so the
+ * decoder is removed while Hum's modern /b/<id> shortlinks keep working.
+ */
+function disable_legacy_ftl_redirect(): void {
+	global $wp_filter;
+
+	if ( ! isset( $wp_filter['hum_legacy_id'] ) ) {
+		return;
+	}
+
+	foreach ( $wp_filter['hum_legacy_id']->callbacks as $priority => $callbacks ) {
+		foreach ( $callbacks as $callback ) {
+			$function = $callback['function'];
+
+			if (
+				\is_array( $function )
+				&& $function[0] instanceof Hum
+				&& $function[1] === 'legacy_ftl_id'
+			) {
+				remove_filter( 'hum_legacy_id', $function, $priority );
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Problem

Hum's `Hum::legacy_ftl_id()` is hooked on `hum_legacy_id` and runs on **every 404**: it strips
non-hex characters from the request path and `base_convert(…, 32, 10)`'s the remainder into a post
ID, then 301-redirects there. This site never used Friendly Twitter Links, and the decoder
misbehaves in two ways:

1. **Spurious 301s.** `/blog/` strips to `b`, decodes to post `11`, and 301s to an unrelated post
   that renders 200 — a soft-404 (bad for SEO/UX). Any short top-level path that survives the hex
   strip is affected.
2. **`ValueError` (Sentry CHRDMDE-6).** A long junk path (e.g. a bot feeding an entire image
   `srcset` as one path) overflows `base_convert()` to `INF`, which PHP 8 refuses to convert
   ("An infinite value cannot be converted to base 10"). 404s anyway, but it's uncaught log noise.

Both are the same feature. A valid base-32 post ID is ≤13 chars (`PHP_INT_MAX` = `7vvvvvvvvvvvv`);
the decoder matches far more broadly than that.

## Fix

A single-file `Apermo\HumLegacyFtl` mu-plugin removes Hum's own `legacy_ftl_id` callback from the
`hum_legacy_id` filter on `init` (priority 20, after Hum registers it). Hum is third-party and
vendored via Composer, so it must not be patched directly; the mu-plugin is the supported seam.

Hum's **modern** `/b/<id>` shortlinks (`parse_request` + rewrite rules, configured here via
`HUM_SHORTLINK_BASE` and used by ActivityPub) are untouched.

## Verification (DDEV, PHP 8.3)

| | `has_filter('hum_legacy_id')` | `apply_filters('hum_legacy_id', 0, 'blog')` | 400-char path |
|---|---|---|---|
| without mu-plugin | `true` | `11` | `ValueError` |
| with mu-plugin | `false` | `0` | no decode, no crash |

## Follow-ups (not in this PR)

- Upstream issue + PR to `pfefferle/wordpress-hum`: guard the `base_convert()` overflow and make the
  legacy FTL redirect opt-in/filterable (current `main` still has the bug verbatim; issue #41 was
  closed stale for lack of a repro).
- Resolve CHRDMDE-6 in Sentry once this is deployed.