### PR TITLE
chore: add temporary upload-trace debug mu-plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@
 !/web/app/mu-plugins/sentry-admin-context.php
 !/web/app/mu-plugins/traduttore-content-dir.php
 !/web/app/mu-plugins/disable-hum-legacy-ftl.php
+!/web/app/mu-plugins/debug-upload-trace.php
 
 # Uploads
 /web/app/uploads/*

--- a/web/app/mu-plugins/debug-upload-trace.php
+++ b/web/app/mu-plugins/debug-upload-trace.php
@@ -61,13 +61,18 @@ function to_sentry( string $message ): void {
 /**
  * Marks the start of metadata generation and arms the fatal-error reporter.
  *
- * @param array $metadata      Attachment metadata being generated.
+ * The value is typed `mixed` rather than `array`: this is a filter callback,
+ * so a misbehaving callback earlier in the chain could pass a non-array, and a
+ * strict hint would then crash the very uploads this plugin exists to diagnose.
+ *
+ * @param mixed $metadata      Attachment metadata being generated.
  * @param int   $attachment_id Attachment post ID.
- * @return array Unmodified attachment metadata.
+ * @return mixed Unmodified attachment metadata.
  */
-function start( array $metadata, int $attachment_id ): array {
-	$GLOBALS['_dut_start'] = \microtime( true );
-	$file                  = get_attached_file( $attachment_id );
+function start( mixed $metadata, int $attachment_id ): mixed {
+	$GLOBALS['_dut_start']              = \microtime( true );
+	$GLOBALS['_dut_current_attachment'] = $attachment_id;
+	$file                               = get_attached_file( $attachment_id );
 
 	trace(
 		\sprintf(
@@ -81,18 +86,21 @@ function start( array $metadata, int $attachment_id ): array {
 	);
 
 	// Fires only on a normal PHP shutdown — i.e. a PHP-level fatal (timeout or
-	// memory exhaustion), NOT an external SIGKILL.
-	\register_shutdown_function( __NAMESPACE__ . '\\report_fatal', $attachment_id );
+	// memory exhaustion), NOT an external SIGKILL. Register once per request so
+	// bulk (multi-attachment) requests don't log/alert the fatal more than once.
+	static $registered = false;
+	if ( ! $registered ) {
+		\register_shutdown_function( __NAMESPACE__ . '\\report_fatal' );
+		$registered = true;
+	}
 
 	return $metadata;
 }
 
 /**
- * Reports the last PHP fatal (if any) for the given attachment to file and Sentry.
- *
- * @param int $attachment_id Attachment post ID.
+ * Reports the last PHP fatal (if any) for the active attachment to file and Sentry.
  */
-function report_fatal( int $attachment_id ): void {
+function report_fatal(): void {
 	$error      = \error_get_last();
 	$fatal_mask = [ \E_ERROR, \E_CORE_ERROR, \E_COMPILE_ERROR, \E_USER_ERROR ];
 
@@ -100,7 +108,8 @@ function report_fatal( int $attachment_id ): void {
 		return;
 	}
 
-	$detail = \sprintf( '%s @ %s:%d', $error['message'], $error['file'], $error['line'] );
+	$attachment_id = $GLOBALS['_dut_current_attachment'] ?? 0;
+	$detail        = \sprintf( '%s @ %s:%d', $error['message'], $error['file'], $error['line'] );
 	trace( 'FATAL ' . $detail );
 	to_sentry( \sprintf( 'Upload sub-size FATAL (att %d): %s', $attachment_id, $detail ) );
 }
@@ -108,11 +117,18 @@ function report_fatal( int $attachment_id ): void {
 /**
  * Records each intermediate size as it is written, revealing the cadence.
  *
- * @param string $path Absolute path to the generated intermediate file.
- * @return string Unmodified file path.
+ * Typed `mixed`: the filter can pass `false`/`null` when an earlier callback
+ * skips or fails a size, so a strict `string` hint would crash the upload.
+ *
+ * @param mixed $path Absolute path to the generated intermediate file, or a non-string on skip/failure.
+ * @return mixed Unmodified file path.
  */
-function after_size( string $path ): string {
-	trace( 'SIZE done: ' . \basename( (string) $path ) );
+function after_size( mixed $path ): mixed {
+	if ( \is_string( $path ) ) {
+		trace( 'SIZE done: ' . \basename( $path ) );
+	} else {
+		trace( 'SIZE failed or skipped (non-string path)' );
+	}
 
 	return $path;
 }
@@ -120,12 +136,12 @@ function after_size( string $path ): string {
 /**
  * Marks a fully completed metadata generation and the resulting size count.
  *
- * @param array $metadata      Completed attachment metadata.
+ * @param mixed $metadata      Completed attachment metadata.
  * @param int   $attachment_id Attachment post ID.
- * @return array Unmodified attachment metadata.
+ * @return mixed Unmodified attachment metadata.
  */
-function finish( array $metadata, int $attachment_id ): array {
-	$count = \is_array( $metadata['sizes'] ?? null ) ? \count( $metadata['sizes'] ) : 0;
+function finish( mixed $metadata, int $attachment_id ): mixed {
+	$count = ( \is_array( $metadata ) && \is_array( $metadata['sizes'] ?? null ) ) ? \count( $metadata['sizes'] ) : 0;
 	trace( \sprintf( 'FINISH att=%d sizes=%d', $attachment_id, $count ) );
 
 	return $metadata;

--- a/web/app/mu-plugins/debug-upload-trace.php
+++ b/web/app/mu-plugins/debug-upload-trace.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Plugin Name: Debug Upload Trace (TEMPORARY)
+ * Description: Traces image upload sub-size generation to a kill-proof file and reports PHP fatals to Sentry, to diagnose silent large-image upload failures. Remove once the upload issue is resolved.
+ */
+
+namespace Apermo\DebugUploadTrace;
+
+use function Sentry\captureMessage;
+
+add_filter( 'wp_generate_attachment_metadata', __NAMESPACE__ . '\\start', 1, 2 );
+add_filter( 'image_make_intermediate_size', __NAMESPACE__ . '\\after_size', 9999, 1 );
+add_filter( 'wp_generate_attachment_metadata', __NAMESPACE__ . '\\finish', 9999, 2 );
+
+/**
+ * Returns the trace log file path inside the uploads directory.
+ *
+ * @return string Absolute path to the trace log file.
+ */
+function log_file(): string {
+	$uploads = wp_upload_dir();
+
+	return $uploads['basedir'] . '/upload-trace.log';
+}
+
+/**
+ * Writes one immediately-flushed trace line.
+ *
+ * Uses an append-and-close write per call so the line survives even a hard
+ * external SIGKILL (e.g. an lsapi/LVE request kill), where a shutdown handler
+ * never runs.
+ *
+ * @param string $message Trace message to append.
+ */
+function trace( string $message ): void {
+	$start = $GLOBALS['_dut_start'] ?? \microtime( true );
+	$line  = \sprintf(
+		"[%s] +%6.2fs mem=%4dM peak=%4dM  %s\n",
+		\gmdate( 'H:i:s' ),
+		\microtime( true ) - $start,
+		\memory_get_usage( true ) / 1048576,
+		\memory_get_peak_usage( true ) / 1048576,
+		$message,
+	);
+
+	// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Direct write is intentional: the line must survive a hard request kill, which the WP_Filesystem FTP transport cannot guarantee.
+	\file_put_contents( log_file(), $line, \FILE_APPEND | \LOCK_EX );
+}
+
+/**
+ * Reports a message to Sentry when the wp-sentry SDK is loaded.
+ *
+ * @param string $message Message to send to Sentry.
+ */
+function to_sentry( string $message ): void {
+	if ( \function_exists( 'Sentry\\captureMessage' ) ) {
+		captureMessage( $message );
+	}
+}
+
+/**
+ * Marks the start of metadata generation and arms the fatal-error reporter.
+ *
+ * @param array $metadata      Attachment metadata being generated.
+ * @param int   $attachment_id Attachment post ID.
+ * @return array Unmodified attachment metadata.
+ */
+function start( array $metadata, int $attachment_id ): array {
+	$GLOBALS['_dut_start'] = \microtime( true );
+	$file                  = get_attached_file( $attachment_id );
+
+	trace(
+		\sprintf(
+			'START att=%d file=%s sapi=%s max_exec=%s mem_limit=%s',
+			$attachment_id,
+			\basename( (string) $file ),
+			\php_sapi_name(),
+			\ini_get( 'max_execution_time' ),
+			\ini_get( 'memory_limit' ),
+		),
+	);
+
+	// Fires only on a normal PHP shutdown — i.e. a PHP-level fatal (timeout or
+	// memory exhaustion), NOT an external SIGKILL.
+	\register_shutdown_function( __NAMESPACE__ . '\\report_fatal', $attachment_id );
+
+	return $metadata;
+}
+
+/**
+ * Reports the last PHP fatal (if any) for the given attachment to file and Sentry.
+ *
+ * @param int $attachment_id Attachment post ID.
+ */
+function report_fatal( int $attachment_id ): void {
+	$error      = \error_get_last();
+	$fatal_mask = [ \E_ERROR, \E_CORE_ERROR, \E_COMPILE_ERROR, \E_USER_ERROR ];
+
+	if ( $error === null || ! \in_array( $error['type'], $fatal_mask, true ) ) {
+		return;
+	}
+
+	$detail = \sprintf( '%s @ %s:%d', $error['message'], $error['file'], $error['line'] );
+	trace( 'FATAL ' . $detail );
+	to_sentry( \sprintf( 'Upload sub-size FATAL (att %d): %s', $attachment_id, $detail ) );
+}
+
+/**
+ * Records each intermediate size as it is written, revealing the cadence.
+ *
+ * @param string $path Absolute path to the generated intermediate file.
+ * @return string Unmodified file path.
+ */
+function after_size( string $path ): string {
+	trace( 'SIZE done: ' . \basename( (string) $path ) );
+
+	return $path;
+}
+
+/**
+ * Marks a fully completed metadata generation and the resulting size count.
+ *
+ * @param array $metadata      Completed attachment metadata.
+ * @param int   $attachment_id Attachment post ID.
+ * @return array Unmodified attachment metadata.
+ */
+function finish( array $metadata, int $attachment_id ): array {
+	$count = \is_array( $metadata['sizes'] ?? null ) ? \count( $metadata['sizes'] ) : 0;
+	trace( \sprintf( 'FINISH att=%d sizes=%d', $attachment_id, $count ) );
+
+	return $metadata;
+}


### PR DESCRIPTION
## Purpose

Temporary instrumentation to diagnose silent large-image upload failures on prod.

Symptom: uploading a large image (e.g. 3168×1344, 7.3 MB PNG with AVIF output)
shows *"Der Server kann das Bild nicht verarbeiten …"*. The attachment row **is**
created but with only the `-scaled` master + the first sub-size (`medium`); all
other sizes are missing. No PHP fatal lands in `WP_DEBUG_LOG` and nothing reaches
Sentry — consistent with the PHP worker being **hard-killed externally** (CloudLinux
lsapi/LVE request limit), which leaves no shutdown trace.

Established so far: AVIF/WebP encoding is fast (sub-second/size), memory is fine
(works at 128 MB), and `wp media regenerate` completes the full size set in ~6 s
from CLI. The failure is specific to the synchronous web upload request being cut
off early — but we can't yet read the exact web-SAPI/lsapi budget.

## What it does

- Hooks `wp_generate_attachment_metadata` (start/finish) and
  `image_make_intermediate_size` (per size).
- Writes an **immediately-flushed** append log to `uploads/upload-trace.log`, so
  the last line survives a hard `SIGKILL` and reveals which operation was running
  and the elapsed time when the request died.
- A `register_shutdown_function` reports any PHP-level fatal (timeout / memory) to
  Sentry, for the case where the failure *is* a catchable/PHP fatal.

## How to read the results

After release, re-upload the failing image, then read
`web/app/uploads/upload-trace.log`:
- A `FATAL …` line (and a Sentry event) → it's a PHP-level limit; the line names it.
- `START` + a few `SIZE done:` lines then **silence**, no `FINISH` → external
  hard-kill; the elapsed timestamp on the last line is the real request budget.

## Notes

- Single-file mu-plugin, `Apermo\DebugUploadTrace` namespace, whitelisted in
  `.gitignore`, passes the `Apermo` PHPCS ruleset (0 errors).
- **Temporary** — remove in a follow-up once the upload issue is resolved.