### PR TITLE
feat: harden REST API against anon enumeration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@
 !/web/app/mu-plugins/traduttore-content-dir.php
 !/web/app/mu-plugins/disable-hum-legacy-ftl.php
 !/web/app/mu-plugins/debug-upload-trace.php
+!/web/app/mu-plugins/rest-hardening.php
 
 # Uploads
 /web/app/uploads/*

--- a/web/app/mu-plugins/rest-hardening.php
+++ b/web/app/mu-plugins/rest-hardening.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Plugin Name: REST API Hardening
+ * Description: Restricts core wp/v2 and batch REST routes to authenticated users to cut user enumeration and content-scraping surface.
+ */
+
+namespace Apermo\RestHardening;
+
+use WP_Error;
+
+add_filter( 'rest_authentication_errors', __NAMESPACE__ . '\\require_authentication' );
+
+/**
+ * Denies unauthenticated access to the core wp/v2 and batch REST routes.
+ *
+ * Core exposes /wp/v2 (notably /wp/v2/users) and /batch/v1 to anonymous
+ * callers by default, which enables username enumeration, bulk content
+ * scraping and the noisy POST /batch/v1 probes seen in error monitoring.
+ * Every other namespace already gates itself through its own permission
+ * callbacks — public-by-design routes (oEmbed, ActivityPub federation,
+ * Contact Form 7 submissions, the Friends browser extension) stay reachable,
+ * and internal _embed dispatch bypasses this authentication filter entirely,
+ * so post embeds keep resolving their author data.
+ *
+ * @param WP_Error|bool|null $result Prior authentication result from earlier filters.
+ * @return WP_Error|bool|null The prior result, or a 401 error for protected routes.
+ */
+function require_authentication( WP_Error|bool|null $result ): WP_Error|bool|null {
+	// Respect a determination another handler already made (true or WP_Error).
+	if ( ! empty( $result ) ) {
+		return $result;
+	}
+
+	if ( is_user_logged_in() ) {
+		return $result;
+	}
+
+	if ( ! is_protected_route( current_route() ) ) {
+		return $result;
+	}
+
+	return new WP_Error(
+		'rest_authentication_required',
+		__( 'This REST endpoint is restricted to authenticated users.', 'rest-hardening' ),
+		[ 'status' => rest_authorization_required_code() ],
+	);
+}
+
+/**
+ * Resolves the REST route being served for the current request.
+ *
+ * Reads the route WordPress parsed from the request, which covers both the
+ * pretty /wp-json/<route> form and the plain ?rest_route=<route> fallback.
+ *
+ * @return string The REST route (e.g. /wp/v2/users), or an empty string.
+ */
+function current_route(): string {
+	if ( isset( $GLOBALS['wp']->query_vars['rest_route'] ) ) {
+		return (string) $GLOBALS['wp']->query_vars['rest_route'];
+	}
+
+	return '';
+}
+
+/**
+ * Determines whether a route belongs to the authenticated-only core namespaces.
+ *
+ * @param string $route The REST route to test.
+ * @return bool True when anonymous access to the route must be denied.
+ */
+function is_protected_route( string $route ): bool {
+	foreach ( [ '/wp/v2', '/batch/' ] as $prefix ) {
+		if ( \str_starts_with( $route, $prefix ) ) {
+			return true;
+		}
+	}
+
+	return false;
+}


### PR DESCRIPTION
## What

Adds a single-file must-use plugin, `web/app/mu-plugins/rest-hardening.php`,
that denies **unauthenticated** access to the core `wp/v2` and `batch` REST
routes via the `rest_authentication_errors` filter.

## Why

Anonymous callers can currently:

- Enumerate usernames through `GET /wp/v2/users` (HTTP 200 today).
- Bulk-scrape content through `/wp/v2/*`.
- Hit `POST /batch/v1`, the source of the noisy warnings in
  Sentry **CHRDMDE-D** (`Constant REST_REQUEST already defined`,
  `Trying to access array offset on null`, `Undefined array key 2`).

## Approach — targeted deny

Rather than a fragile default-deny allowlist, this closes the one surface that
is actually open to anonymous users yet not required for the site to function:
core `wp/v2` (incl. `users`) and `batch/v1`. Every other namespace already
enforces its own permission callbacks, so anon is already locked out there.

Left intact on purpose:

- **oEmbed**, **ActivityPub** (federation), **Contact Form 7** (submissions),
  and the public **Friends** browser-extension route — each is public by design.
- Internal `_embed` dispatch, which bypasses `rest_authentication_errors`
  entirely, so post embeds keep resolving author data.
- Authenticated requests (cookie+nonce or application password) — unaffected.

Statify analytics is unaffected: it tracks via `admin-ajax.php`
(`wp_ajax_nopriv_statify_track`), not REST.

Hardcoded, no filters/constants — behaviour changes are code changes, as fits
a mu-plugin.

## Verification (local DDEV)

| Case | Route | Result |
|------|-------|--------|
| Anon | `GET /wp/v2/users` | **401** |
| Anon | `GET /wp/v2/posts` / `media` | **401** |
| Anon | `?rest_route=/wp/v2/users` | **401** |
| Anon | `POST /batch/v1` | **401** |
| Anon | `GET /wp-json/` (index) | 200 |
| Anon | `oembed/1.0/embed` (real post) | 200 |
| Anon | `activitypub/1.0/actors/1` | 400 (own gate) |
| Auth | `GET /wp/v2/users` | **200** |
| — | Homepage | 200 |

PHPCS (`Apermo` ruleset): file passes with 0 errors (only the shared
`Plugin Name:` header warning common to all mu-plugins).

Refs Sentry CHRDMDE-D.